### PR TITLE
Improve pinentry handling

### DIFF
--- a/nitrocli/src/main.rs
+++ b/nitrocli/src/main.rs
@@ -253,8 +253,9 @@ fn open() -> Result<()> {
 
   nitrokey_do(&|handle| {
     let mut retry = 3;
+    let mut error_msg: Option<&str> = None;
     loop {
-      let passphrase = pinentry::inquire_passphrase()?;
+      let passphrase = pinentry::inquire_passphrase(error_msg)?;
       let payload = nitrokey::EnableEncryptedVolumeCommand::new(&passphrase);
       let report = nitrokey::Report::from(payload);
 
@@ -267,7 +268,7 @@ fn open() -> Result<()> {
         retry -= 1;
 
         if retry > 0 {
-          println!("Wrong password, please reenter");
+          error_msg = Some("Wrong password, please reenter");
           continue;
         }
         let error = "Opening encrypted volume failed: Wrong password";

--- a/nitrocli/src/main.rs
+++ b/nitrocli/src/main.rs
@@ -42,6 +42,7 @@ type Result<T> = result::Result<T, Error>;
 type NitroFunc = Fn(&mut libhid::Handle) -> Result<()>;
 
 
+const PIN_TYPE: pinentry::PinType = pinentry::PinType::User;
 const SEND_TRY_COUNT: i8 = 3;
 const RECV_TRY_COUNT: i8 = 40;
 const SEND_RECV_DELAY_MS: u64 = 200;
@@ -255,7 +256,7 @@ fn open() -> Result<()> {
     let mut retry = 3;
     let mut error_msg: Option<&str> = None;
     loop {
-      let passphrase = pinentry::inquire_passphrase(error_msg)?;
+      let passphrase = pinentry::inquire_passphrase(PIN_TYPE, error_msg)?;
       let payload = nitrokey::EnableEncryptedVolumeCommand::new(&passphrase);
       let report = nitrokey::Report::from(payload);
 
@@ -264,7 +265,7 @@ fn open() -> Result<()> {
       let mut status = response.data.storage_status;
 
       if status == nitrokey::StorageStatus::WrongPassword {
-        pinentry::clear_passphrase()?;
+        pinentry::clear_passphrase(PIN_TYPE)?;
         retry -= 1;
 
         if retry > 0 {
@@ -328,7 +329,7 @@ fn close() -> Result<()> {
 
 /// Clear the PIN stored when opening the nitrokey's encrypted volume.
 fn clear() -> Result<()> {
-  pinentry::clear_passphrase()
+  pinentry::clear_passphrase(PIN_TYPE)
 }
 
 

--- a/nitrocli/src/pinentry.rs
+++ b/nitrocli/src/pinentry.rs
@@ -21,7 +21,7 @@ use error::Error;
 use std::process;
 
 
-const CACHE_ID: &str = "nitrokey";
+const CACHE_ID: &str = "nitrocli:user";
 
 
 fn parse_pinentry_passphrase(response: Vec<u8>) -> Result<Vec<u8>, Error> {

--- a/nitrocli/src/pinentry.rs
+++ b/nitrocli/src/pinentry.rs
@@ -49,12 +49,14 @@ fn parse_pinentry_passphrase(response: Vec<u8>) -> Result<Vec<u8>, Error> {
 }
 
 
-pub fn inquire_passphrase() -> Result<Vec<u8>, Error> {
-  const PINENTRY_ERROR_MSG: &str = "+";
+pub fn inquire_passphrase(error_msg: Option<&str>) -> Result<Vec<u8>, Error> {
+  const PINENTRY_ERROR_MSG_EMPTY: &str = "+";
   const PINENTRY_PROMPT: &str = "PIN";
   const PINENTRY_DESCR: &str = "Please+enter+user+PIN";
 
-  let args = vec![CACHE_ID, PINENTRY_ERROR_MSG, PINENTRY_PROMPT, PINENTRY_DESCR].join(" ");
+  let error_msg = error_msg.map(|msg| msg.replace(" ", "+"))
+    .unwrap_or(PINENTRY_ERROR_MSG_EMPTY.to_string());
+  let args = vec![CACHE_ID, &error_msg, PINENTRY_PROMPT, PINENTRY_DESCR].join(" ");
   let command = "GET_PASSPHRASE --data ".to_string() + &args;
   // We could also use the --data parameter here to have a more direct
   // representation of the passphrase but the resulting response was

--- a/nitrocli/src/pinentry.rs
+++ b/nitrocli/src/pinentry.rs
@@ -50,11 +50,11 @@ fn parse_pinentry_passphrase(response: Vec<u8>) -> Result<Vec<u8>, Error> {
 
 
 pub fn inquire_passphrase() -> Result<Vec<u8>, Error> {
-  const PINENTRY_DESCR: &str = "+";
-  const PINENTRY_TITLE: &str = "Please+enter+user+PIN";
-  const PINENTRY_PASSWD: &str = "PIN";
+  const PINENTRY_ERROR_MSG: &str = "+";
+  const PINENTRY_PROMPT: &str = "PIN";
+  const PINENTRY_DESCR: &str = "Please+enter+user+PIN";
 
-  let args = vec![CACHE_ID, PINENTRY_DESCR, PINENTRY_PASSWD, PINENTRY_TITLE].join(" ");
+  let args = vec![CACHE_ID, PINENTRY_ERROR_MSG, PINENTRY_PROMPT, PINENTRY_DESCR].join(" ");
   let command = "GET_PASSPHRASE --data ".to_string() + &args;
   // We could also use the --data parameter here to have a more direct
   // representation of the passphrase but the resulting response was

--- a/nitrocli/src/pinentry.rs
+++ b/nitrocli/src/pinentry.rs
@@ -83,6 +83,10 @@ fn parse_pinentry_passphrase(response: Vec<u8>) -> Result<Vec<u8>, Error> {
 }
 
 
+/// Inquire a PIN of the given type from the user.
+///
+/// This function inquires a PIN of the given type from the user or returns the cached passphrase,
+/// if available.  If an error message is set, it is displayed in the passphrase dialog.
 pub fn inquire_passphrase(pin_type: PinType, error_msg: Option<&str>) -> Result<Vec<u8>, Error> {
   let cache_id = pin_type.cache_id();
   let error_msg = error_msg.map(|msg| msg.replace(" ", "+")).unwrap_or(String::from("+"));


### PR DESCRIPTION
This pull requests contains several patches that improve pinentry handling.  The major changes are:

- Use a more specific cache ID to allow querying different PINs (e. g. user PIN and admin PIN).
- Display error messages in the pinentry dialog (if possible) instead of the command line.