### PR TITLE
Add rustfmt configuration

### DIFF
--- a/nitrocli/rustfmt.toml
+++ b/nitrocli/rustfmt.toml
@@ -1,0 +1,1 @@
+tab_spaces = 2


### PR DESCRIPTION
rustfmt uses four-space indentation per default.  This patch adds a configuration file that sets the indentation with to two spaces.