### PR TITLE
Add a .gitignore file

### DIFF
--- a/nitrocli/.gitignore
+++ b/nitrocli/.gitignore
@@ -1,0 +1,2 @@
+target
+*.swp


### PR DESCRIPTION
This patch adds a .gitignore file that ignores the target directory that is created by cargo during compilation and swap files created by vim.