### PR TITLE
pinentry: Encode spaces in prompt argument

### DIFF
--- a/nitrocli/CHANGELOG.md
+++ b/nitrocli/CHANGELOG.md
@@ -10,6 +10,8 @@ Unreleased
   and building of the project
 - Added badges indicating pipeline status, current `crates.io` published
   version of the crate, and minimum version of `rustc` required
+- Fixed wrong messages in the pinentry dialog that were caused by unescaped
+  spaces in a string
 
 
 0.1.3

--- a/nitrocli/src/pinentry.rs
+++ b/nitrocli/src/pinentry.rs
@@ -90,10 +90,10 @@ pub fn inquire_passphrase(pin_type: PinType, error_msg: Option<&str>) -> Result<
   let error_msg = error_msg
     .map(|msg| msg.replace(" ", "+"))
     .unwrap_or_else(|| String::from("+"));
-  let prompt = pin_type.prompt();
+  let prompt = pin_type.prompt().replace(" ", "+");
   let description = pin_type.description().replace(" ", "+");
 
-  let args = vec![cache_id, &error_msg, prompt, &description].join(" ");
+  let args = vec![cache_id, &error_msg, &prompt, &description].join(" ");
   let command = "GET_PASSPHRASE --data ".to_string() + &args;
   // We could also use the --data parameter here to have a more direct
   // representation of the passphrase but the resulting response was


### PR DESCRIPTION
Spaces in the arguments for gpg-connect-agent’s `GET_PASSPHRASE` command have to be esaced using a plus sign.  Somehow this was missing for the prompt argument.  This patch adds escaping for the prompt so that the pinentry dialog is displayed correctly.