### PR TITLE
Add the --model option to restrict the device model to connect to

### DIFF
--- a/nitrocli/CHANGELOG.md
+++ b/nitrocli/CHANGELOG.md
@@ -4,6 +4,8 @@ Unreleased
 - Added the `lock` command for locking the Nitrokey device
 - Added the `-v` and `--verbose` options to control libnitrokey log
   level
+- Added the `-m` and `--model` options to restrict connections to
+  a device model
 - Adjust release build compile options to optimize binary for size
 - Bumped `nitrokey` dependency to `0.2.3`
   - Bumped `rand` dependency to `0.6.1`

--- a/nitrocli/doc/nitrocli.1
+++ b/nitrocli/doc/nitrocli.1
@@ -13,7 +13,12 @@ It can be used to access the encrypted volume, the one-time password generator,
 and the password safe.
 .SH OPTIONS
 .TP
-.B \-v, \-\-verbose
+\fB\-m\fR, \fB\-\-model pro\fR|\fBstorage\fR
+Restrict connections to the given device model.
+If this option is not set, nitrocli will connect to any connected Nitrokey Pro
+or Nitrokey Storage device.
+.TP
+\fB\-v\fR, \fB\-\-verbose\fR
 Enable additional logging and control its verbosity. Logging enabled through
 this option will appear on the standard error stream. This option can be
 supplied multiple times. A single occurrence will show additional warnings.


### PR DESCRIPTION
This patch adds the -m, --model option that can be used to restrict the
device model to connect to.  Per default, nitrocli connects to any
available Nitrokey device.  If this new option is set, it will instead
only connect to devices of the given Nitrokey model.

We introduce a new struct DeviceModel instead of using
nitrokey::DeviceModel to make sure that the command-line options are
parsed properly.  On the long term, we should add a connect_model
function to the nitrokey crate to make the connection code easier.