### PR TITLE
Implement the first Nitrokey device test

### DIFF
--- a/nitrocli/Cargo.lock
+++ b/nitrocli/Cargo.lock
@@ -56,6 +56,7 @@ dependencies = [
  "argparse 0.2.2",
  "libc 0.2.45",
  "nitrokey 0.3.0",
+ "nitrokey-test 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -79,6 +80,32 @@ name = "nitrokey-sys"
 version = "3.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 replace = "nitrokey-sys 3.4.1"
+
+[[package]]
+name = "nitrokey-test"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.23 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "0.4.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "quote"
+version = "0.6.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "rand"
@@ -181,6 +208,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 replace = "semver-parser 0.7.0"
 
 [[package]]
+name = "syn"
+version = "0.15.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "unicode-xid"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "winapi"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -207,10 +249,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)" = "2d2857ec59fadc0773853c664d2d18e7198e83883e7060b63c924cb077bd5c74"
 "checksum nitrokey-sys 3.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "34794d630d40a093a3f0e31b821b38ee1c16e6909dc42064feff28f4798484f4"
+"checksum nitrokey-test 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1f1f3660ac7f19d3839727f23ab5feb34a9b5e2c9f182393a938559ccd70a001"
+"checksum proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)" = "77619697826f31a02ae974457af0b29b723e5619e113e9397b8b82c6bd253f09"
+"checksum quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "53fa22a1994bd0f9372d7a816207d8a2677ad0325b073f5c5332760f0fb62b5c"
 "checksum rand 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ae9d223d52ae411a33cf7e54ec6034ec165df296ccd23533d671a28252b6f66a"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+"checksum syn 0.15.23 (registry+https://github.com/rust-lang/crates.io-index)" = "9545a6a093a3f0bd59adb472700acc08cad3776f860f16a897dfce8c88721cbc"
+"checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/nitrocli/Cargo.toml
+++ b/nitrocli/Cargo.toml
@@ -53,6 +53,8 @@ path = "../libc"
 version = "0.3"
 path = "../nitrokey"
 
+[dev-dependencies.nitrokey-test]
+version = "0.1.0"
 
 [replace]
 "cc:1.0.28" = { path = "../cc" }

--- a/nitrocli/src/args.rs
+++ b/nitrocli/src/args.rs
@@ -63,9 +63,10 @@ impl str::FromStr for DeviceModel {
 /// A command execution context that captures additional data pertaining
 /// the command execution.
 #[derive(Debug)]
-pub struct ExecCtx {
+pub struct ExecCtx<'io> {
   pub model: Option<DeviceModel>,
   pub verbosity: u64,
+  data: std::marker::PhantomData<&'io u64>,
 }
 
 /// A top-level command for nitrocli.
@@ -82,7 +83,7 @@ pub enum Command {
 
 impl Command {
   /// Execute this command with the given arguments.
-  pub fn execute(&self, ctx: &ExecCtx, args: Vec<String>) -> Result<()> {
+  pub fn execute(&self, ctx: &mut ExecCtx<'_>, args: Vec<String>) -> Result<()> {
     match *self {
       Command::Config => config(ctx, args),
       Command::Lock => lock(ctx, args),
@@ -137,7 +138,7 @@ enum ConfigCommand {
 }
 
 impl ConfigCommand {
-  fn execute(&self, ctx: &ExecCtx, args: Vec<String>) -> Result<()> {
+  fn execute(&self, ctx: &mut ExecCtx<'_>, args: Vec<String>) -> Result<()> {
     match *self {
       ConfigCommand::Get => config_get(ctx, args),
       ConfigCommand::Set => config_set(ctx, args),
@@ -214,7 +215,7 @@ enum OtpCommand {
 }
 
 impl OtpCommand {
-  fn execute(&self, ctx: &ExecCtx, args: Vec<String>) -> Result<()> {
+  fn execute(&self, ctx: &mut ExecCtx<'_>, args: Vec<String>) -> Result<()> {
     match *self {
       OtpCommand::Clear => otp_clear(ctx, args),
       OtpCommand::Get => otp_get(ctx, args),
@@ -332,7 +333,7 @@ enum PinCommand {
 }
 
 impl PinCommand {
-  fn execute(&self, ctx: &ExecCtx, args: Vec<String>) -> Result<()> {
+  fn execute(&self, ctx: &mut ExecCtx<'_>, args: Vec<String>) -> Result<()> {
     match *self {
       PinCommand::Clear => pin_clear(args),
       PinCommand::Set => pin_set(ctx, args),
@@ -377,7 +378,7 @@ enum PwsCommand {
 }
 
 impl PwsCommand {
-  fn execute(&self, ctx: &ExecCtx, args: Vec<String>) -> Result<()> {
+  fn execute(&self, ctx: &mut ExecCtx<'_>, args: Vec<String>) -> Result<()> {
     match *self {
       PwsCommand::Clear => pws_clear(ctx, args),
       PwsCommand::Get => pws_get(ctx, args),
@@ -425,7 +426,7 @@ fn parse(parser: &argparse::ArgumentParser<'_>, args: Vec<String>) -> Result<()>
 }
 
 /// Inquire the status of the nitrokey.
-fn status(ctx: &ExecCtx, args: Vec<String>) -> Result<()> {
+fn status(ctx: &mut ExecCtx<'_>, args: Vec<String>) -> Result<()> {
   let mut parser = argparse::ArgumentParser::new();
   parser.set_description("Prints the status of the connected Nitrokey device");
   parse(&parser, args)?;
@@ -441,7 +442,7 @@ enum StorageCommand {
 }
 
 impl StorageCommand {
-  fn execute(&self, ctx: &ExecCtx, args: Vec<String>) -> Result<()> {
+  fn execute(&self, ctx: &mut ExecCtx<'_>, args: Vec<String>) -> Result<()> {
     match *self {
       StorageCommand::Close => storage_close(ctx, args),
       StorageCommand::Open => storage_open(ctx, args),
@@ -478,7 +479,7 @@ impl str::FromStr for StorageCommand {
 }
 
 /// Execute a storage subcommand.
-fn storage(ctx: &ExecCtx, args: Vec<String>) -> Result<()> {
+fn storage(ctx: &mut ExecCtx<'_>, args: Vec<String>) -> Result<()> {
   let mut subcommand = StorageCommand::Open;
   let mut subargs = vec![];
   let mut parser = argparse::ArgumentParser::new();
@@ -502,7 +503,7 @@ fn storage(ctx: &ExecCtx, args: Vec<String>) -> Result<()> {
 }
 
 /// Open the encrypted volume on the nitrokey.
-fn storage_open(ctx: &ExecCtx, args: Vec<String>) -> Result<()> {
+fn storage_open(ctx: &mut ExecCtx<'_>, args: Vec<String>) -> Result<()> {
   let mut parser = argparse::ArgumentParser::new();
   parser.set_description("Opens the encrypted volume on a Nitrokey Storage");
   parse(&parser, args)?;
@@ -511,7 +512,7 @@ fn storage_open(ctx: &ExecCtx, args: Vec<String>) -> Result<()> {
 }
 
 /// Close the previously opened encrypted volume.
-fn storage_close(ctx: &ExecCtx, args: Vec<String>) -> Result<()> {
+fn storage_close(ctx: &mut ExecCtx<'_>, args: Vec<String>) -> Result<()> {
   let mut parser = argparse::ArgumentParser::new();
   parser.set_description("Closes the encrypted volume on a Nitrokey Storage");
   parse(&parser, args)?;
@@ -520,7 +521,7 @@ fn storage_close(ctx: &ExecCtx, args: Vec<String>) -> Result<()> {
 }
 
 /// Print the status of the nitrokey's storage.
-fn storage_status(ctx: &ExecCtx, args: Vec<String>) -> Result<()> {
+fn storage_status(ctx: &mut ExecCtx<'_>, args: Vec<String>) -> Result<()> {
   let mut parser = argparse::ArgumentParser::new();
   parser.set_description("Prints the status of the Nitrokey's storage");
   parse(&parser, args)?;
@@ -529,7 +530,7 @@ fn storage_status(ctx: &ExecCtx, args: Vec<String>) -> Result<()> {
 }
 
 /// Execute a config subcommand.
-fn config(ctx: &ExecCtx, args: Vec<String>) -> Result<()> {
+fn config(ctx: &mut ExecCtx<'_>, args: Vec<String>) -> Result<()> {
   let mut subcommand = ConfigCommand::Get;
   let mut subargs = vec![];
   let mut parser = argparse::ArgumentParser::new();
@@ -553,7 +554,7 @@ fn config(ctx: &ExecCtx, args: Vec<String>) -> Result<()> {
 }
 
 /// Read the Nitrokey configuration.
-fn config_get(ctx: &ExecCtx, args: Vec<String>) -> Result<()> {
+fn config_get(ctx: &mut ExecCtx<'_>, args: Vec<String>) -> Result<()> {
   let mut parser = argparse::ArgumentParser::new();
   parser.set_description("Prints the Nitrokey configuration");
   parse(&parser, args)?;
@@ -562,7 +563,7 @@ fn config_get(ctx: &ExecCtx, args: Vec<String>) -> Result<()> {
 }
 
 /// Write the Nitrokey configuration.
-fn config_set(ctx: &ExecCtx, args: Vec<String>) -> Result<()> {
+fn config_set(ctx: &mut ExecCtx<'_>, args: Vec<String>) -> Result<()> {
   let mut numlock = None;
   let mut no_numlock = false;
   let mut capslock = None;
@@ -630,7 +631,7 @@ fn config_set(ctx: &ExecCtx, args: Vec<String>) -> Result<()> {
 }
 
 /// Lock the Nitrokey.
-fn lock(ctx: &ExecCtx, args: Vec<String>) -> Result<()> {
+fn lock(ctx: &mut ExecCtx<'_>, args: Vec<String>) -> Result<()> {
   let mut parser = argparse::ArgumentParser::new();
   parser.set_description("Locks the connected Nitrokey device");
   parse(&parser, args)?;
@@ -639,7 +640,7 @@ fn lock(ctx: &ExecCtx, args: Vec<String>) -> Result<()> {
 }
 
 /// Execute an OTP subcommand.
-fn otp(ctx: &ExecCtx, args: Vec<String>) -> Result<()> {
+fn otp(ctx: &mut ExecCtx<'_>, args: Vec<String>) -> Result<()> {
   let mut subcommand = OtpCommand::Get;
   let mut subargs = vec![];
   let mut parser = argparse::ArgumentParser::new();
@@ -663,7 +664,7 @@ fn otp(ctx: &ExecCtx, args: Vec<String>) -> Result<()> {
 }
 
 /// Generate a one-time password on the Nitrokey device.
-fn otp_get(ctx: &ExecCtx, args: Vec<String>) -> Result<()> {
+fn otp_get(ctx: &mut ExecCtx<'_>, args: Vec<String>) -> Result<()> {
   let mut slot: u8 = 0;
   let mut algorithm = OtpAlgorithm::Totp;
   let mut time: Option<u64> = None;
@@ -691,7 +692,7 @@ fn otp_get(ctx: &ExecCtx, args: Vec<String>) -> Result<()> {
 }
 
 /// Configure a one-time password slot on the Nitrokey device.
-pub fn otp_set(ctx: &ExecCtx, args: Vec<String>) -> Result<()> {
+pub fn otp_set(ctx: &mut ExecCtx<'_>, args: Vec<String>) -> Result<()> {
   let mut slot: u8 = 0;
   let mut algorithm = OtpAlgorithm::Totp;
   let mut name = "".to_owned();
@@ -757,7 +758,7 @@ pub fn otp_set(ctx: &ExecCtx, args: Vec<String>) -> Result<()> {
 }
 
 /// Clear an OTP slot.
-fn otp_clear(ctx: &ExecCtx, args: Vec<String>) -> Result<()> {
+fn otp_clear(ctx: &mut ExecCtx<'_>, args: Vec<String>) -> Result<()> {
   let mut slot: u8 = 0;
   let mut algorithm = OtpAlgorithm::Totp;
   let mut parser = argparse::ArgumentParser::new();
@@ -779,7 +780,7 @@ fn otp_clear(ctx: &ExecCtx, args: Vec<String>) -> Result<()> {
 }
 
 /// Print the status of the OTP slots.
-fn otp_status(ctx: &ExecCtx, args: Vec<String>) -> Result<()> {
+fn otp_status(ctx: &mut ExecCtx<'_>, args: Vec<String>) -> Result<()> {
   let mut all = false;
   let mut parser = argparse::ArgumentParser::new();
   parser.set_description("Prints the status of the OTP slots");
@@ -795,7 +796,7 @@ fn otp_status(ctx: &ExecCtx, args: Vec<String>) -> Result<()> {
 }
 
 /// Execute a PIN subcommand.
-fn pin(ctx: &ExecCtx, args: Vec<String>) -> Result<()> {
+fn pin(ctx: &mut ExecCtx<'_>, args: Vec<String>) -> Result<()> {
   let mut subcommand = PinCommand::Clear;
   let mut subargs = vec![];
   let mut parser = argparse::ArgumentParser::new();
@@ -828,7 +829,7 @@ fn pin_clear(args: Vec<String>) -> Result<()> {
 }
 
 /// Change a PIN.
-fn pin_set(ctx: &ExecCtx, args: Vec<String>) -> Result<()> {
+fn pin_set(ctx: &mut ExecCtx<'_>, args: Vec<String>) -> Result<()> {
   let mut pintype = pinentry::PinType::User;
   let mut parser = argparse::ArgumentParser::new();
   parser.set_description("Changes a PIN");
@@ -844,7 +845,7 @@ fn pin_set(ctx: &ExecCtx, args: Vec<String>) -> Result<()> {
 }
 
 /// Unblock and reset the user PIN.
-fn pin_unblock(ctx: &ExecCtx, args: Vec<String>) -> Result<()> {
+fn pin_unblock(ctx: &mut ExecCtx<'_>, args: Vec<String>) -> Result<()> {
   let mut parser = argparse::ArgumentParser::new();
   parser.set_description("Unblocks and resets the user PIN");
   parse(&parser, args)?;
@@ -853,7 +854,7 @@ fn pin_unblock(ctx: &ExecCtx, args: Vec<String>) -> Result<()> {
 }
 
 /// Execute a PWS subcommand.
-fn pws(ctx: &ExecCtx, args: Vec<String>) -> Result<()> {
+fn pws(ctx: &mut ExecCtx<'_>, args: Vec<String>) -> Result<()> {
   let mut subcommand = PwsCommand::Get;
   let mut subargs = vec![];
   let mut parser = argparse::ArgumentParser::new();
@@ -877,7 +878,7 @@ fn pws(ctx: &ExecCtx, args: Vec<String>) -> Result<()> {
 }
 
 /// Access a slot of the password safe on the Nitrokey.
-fn pws_get(ctx: &ExecCtx, args: Vec<String>) -> Result<()> {
+fn pws_get(ctx: &mut ExecCtx<'_>, args: Vec<String>) -> Result<()> {
   let mut slot: u8 = 0;
   let mut name = false;
   let mut login = false;
@@ -917,7 +918,7 @@ fn pws_get(ctx: &ExecCtx, args: Vec<String>) -> Result<()> {
 }
 
 /// Set a slot of the password safe on the Nitrokey.
-fn pws_set(ctx: &ExecCtx, args: Vec<String>) -> Result<()> {
+fn pws_set(ctx: &mut ExecCtx<'_>, args: Vec<String>) -> Result<()> {
   let mut slot: u8 = 0;
   let mut name = String::new();
   let mut login = String::new();
@@ -951,7 +952,7 @@ fn pws_set(ctx: &ExecCtx, args: Vec<String>) -> Result<()> {
 }
 
 /// Clear a PWS slot.
-fn pws_clear(ctx: &ExecCtx, args: Vec<String>) -> Result<()> {
+fn pws_clear(ctx: &mut ExecCtx<'_>, args: Vec<String>) -> Result<()> {
   let mut slot: u8 = 0;
   let mut parser = argparse::ArgumentParser::new();
   parser.set_description("Clears a password safe slot");
@@ -967,7 +968,7 @@ fn pws_clear(ctx: &ExecCtx, args: Vec<String>) -> Result<()> {
 }
 
 /// Print the status of the PWS slots.
-fn pws_status(ctx: &ExecCtx, args: Vec<String>) -> Result<()> {
+fn pws_status(ctx: &mut ExecCtx<'_>, args: Vec<String>) -> Result<()> {
   let mut all = false;
   let mut parser = argparse::ArgumentParser::new();
   parser.set_description("Prints the status of the PWS slots");
@@ -984,7 +985,7 @@ fn pws_status(ctx: &ExecCtx, args: Vec<String>) -> Result<()> {
 
 /// Parse the command-line arguments and return the selected command and
 /// the remaining arguments for the command.
-fn parse_arguments(args: Vec<String>) -> Result<(Command, ExecCtx, Vec<String>)> {
+fn parse_arguments<'io>(args: Vec<String>) -> Result<(Command, ExecCtx<'io>, Vec<String>)> {
   let mut model: Option<DeviceModel> = None;
   let mut verbosity = 0;
   let mut command = Command::Status;
@@ -1017,12 +1018,12 @@ fn parse_arguments(args: Vec<String>) -> Result<(Command, ExecCtx, Vec<String>)>
 
   subargs.insert(0, format!("nitrocli {}", command));
 
-  let ctx = ExecCtx { model, verbosity };
+  let ctx = ExecCtx { model, verbosity, data: Default::default() };
   Ok((command, ctx, subargs))
 }
 
 /// Parse the command-line arguments and execute the selected command.
 pub fn handle_arguments(args: Vec<String>) -> Result<()> {
-  let (command, ctx, args) = parse_arguments(args)?;
-  command.execute(&ctx, args)
+  let (command, mut ctx, args) = parse_arguments(args)?;
+  command.execute(&mut ctx, args)
 }

--- a/nitrocli/src/args.rs
+++ b/nitrocli/src/args.rs
@@ -60,13 +60,34 @@ impl str::FromStr for DeviceModel {
   }
 }
 
+trait Stdio {
+  fn stdio(&mut self) -> (&mut dyn io::Write, &mut dyn io::Write);
+}
+
+struct ParseCtx<'io> {
+  pub stdout: &'io mut dyn io::Write,
+  pub stderr: &'io mut dyn io::Write,
+}
+
+impl<'io> Stdio for ParseCtx<'io> {
+  fn stdio(&mut self) -> (&mut dyn io::Write, &mut dyn io::Write) {
+    (self.stdout, self.stderr)
+  }
+}
+
 /// A command execution context that captures additional data pertaining
 /// the command execution.
-#[derive(Debug)]
 pub struct ExecCtx<'io> {
   pub model: Option<DeviceModel>,
+  pub stdout: &'io mut dyn io::Write,
+  pub stderr: &'io mut dyn io::Write,
   pub verbosity: u64,
-  data: std::marker::PhantomData<&'io u64>,
+}
+
+impl<'io> Stdio for ExecCtx<'io> {
+  fn stdio(&mut self) -> (&mut dyn io::Write, &mut dyn io::Write) {
+    (self.stdout, self.stderr)
+  }
 }
 
 /// A top-level command for nitrocli.
@@ -335,7 +356,7 @@ enum PinCommand {
 impl PinCommand {
   fn execute(&self, ctx: &mut ExecCtx<'_>, args: Vec<String>) -> Result<()> {
     match *self {
-      PinCommand::Clear => pin_clear(args),
+      PinCommand::Clear => pin_clear(ctx, args),
       PinCommand::Set => pin_set(ctx, args),
       PinCommand::Unblock => pin_unblock(ctx, args),
     }
@@ -417,8 +438,13 @@ impl str::FromStr for PwsCommand {
   }
 }
 
-fn parse(parser: &argparse::ArgumentParser<'_>, args: Vec<String>) -> Result<()> {
-  if let Err(err) = parser.parse(args, &mut io::stdout(), &mut io::stderr()) {
+fn parse(
+  ctx: &mut impl Stdio,
+  parser: &argparse::ArgumentParser<'_>,
+  args: Vec<String>,
+) -> Result<()> {
+  let (stdout, stderr) = ctx.stdio();
+  if let Err(err) = parser.parse(args, stdout, stderr) {
     Err(Error::ArgparseError(err))
   } else {
     Ok(())
@@ -429,7 +455,7 @@ fn parse(parser: &argparse::ArgumentParser<'_>, args: Vec<String>) -> Result<()>
 fn status(ctx: &mut ExecCtx<'_>, args: Vec<String>) -> Result<()> {
   let mut parser = argparse::ArgumentParser::new();
   parser.set_description("Prints the status of the connected Nitrokey device");
-  parse(&parser, args)?;
+  parse(ctx, &parser, args)?;
 
   commands::status(ctx)
 }
@@ -495,7 +521,7 @@ fn storage(ctx: &mut ExecCtx<'_>, args: Vec<String>) -> Result<()> {
     "The arguments for the subcommand",
   );
   parser.stop_on_first_argument(true);
-  parse(&parser, args)?;
+  parse(ctx, &parser, args)?;
   drop(parser);
 
   subargs.insert(0, format!("nitrocli storage {}", subcommand));
@@ -506,7 +532,7 @@ fn storage(ctx: &mut ExecCtx<'_>, args: Vec<String>) -> Result<()> {
 fn storage_open(ctx: &mut ExecCtx<'_>, args: Vec<String>) -> Result<()> {
   let mut parser = argparse::ArgumentParser::new();
   parser.set_description("Opens the encrypted volume on a Nitrokey Storage");
-  parse(&parser, args)?;
+  parse(ctx, &parser, args)?;
 
   commands::storage_open(ctx)
 }
@@ -515,7 +541,7 @@ fn storage_open(ctx: &mut ExecCtx<'_>, args: Vec<String>) -> Result<()> {
 fn storage_close(ctx: &mut ExecCtx<'_>, args: Vec<String>) -> Result<()> {
   let mut parser = argparse::ArgumentParser::new();
   parser.set_description("Closes the encrypted volume on a Nitrokey Storage");
-  parse(&parser, args)?;
+  parse(ctx, &parser, args)?;
 
   commands::storage_close(ctx)
 }
@@ -524,7 +550,7 @@ fn storage_close(ctx: &mut ExecCtx<'_>, args: Vec<String>) -> Result<()> {
 fn storage_status(ctx: &mut ExecCtx<'_>, args: Vec<String>) -> Result<()> {
   let mut parser = argparse::ArgumentParser::new();
   parser.set_description("Prints the status of the Nitrokey's storage");
-  parse(&parser, args)?;
+  parse(ctx, &parser, args)?;
 
   commands::storage_status(ctx)
 }
@@ -546,7 +572,7 @@ fn config(ctx: &mut ExecCtx<'_>, args: Vec<String>) -> Result<()> {
     "The arguments for the subcommand",
   );
   parser.stop_on_first_argument(true);
-  parse(&parser, args)?;
+  parse(ctx, &parser, args)?;
   drop(parser);
 
   subargs.insert(0, format!("nitrocli config {}", subcommand));
@@ -557,7 +583,7 @@ fn config(ctx: &mut ExecCtx<'_>, args: Vec<String>) -> Result<()> {
 fn config_get(ctx: &mut ExecCtx<'_>, args: Vec<String>) -> Result<()> {
   let mut parser = argparse::ArgumentParser::new();
   parser.set_description("Prints the Nitrokey configuration");
-  parse(&parser, args)?;
+  parse(ctx, &parser, args)?;
 
   commands::config_get(ctx)
 }
@@ -614,7 +640,7 @@ fn config_set(ctx: &mut ExecCtx<'_>, args: Vec<String>) -> Result<()> {
     argparse::StoreTrue,
     "Allow one-time password generation without PIN",
   );
-  parse(&parser, args)?;
+  parse(ctx, &parser, args)?;
   drop(parser);
 
   let numlock = ConfigOption::try_from(no_numlock, numlock, "numlock")?;
@@ -634,7 +660,7 @@ fn config_set(ctx: &mut ExecCtx<'_>, args: Vec<String>) -> Result<()> {
 fn lock(ctx: &mut ExecCtx<'_>, args: Vec<String>) -> Result<()> {
   let mut parser = argparse::ArgumentParser::new();
   parser.set_description("Locks the connected Nitrokey device");
-  parse(&parser, args)?;
+  parse(ctx, &parser, args)?;
 
   commands::lock(ctx)
 }
@@ -656,7 +682,7 @@ fn otp(ctx: &mut ExecCtx<'_>, args: Vec<String>) -> Result<()> {
     "The arguments for the subcommand",
   );
   parser.stop_on_first_argument(true);
-  parse(&parser, args)?;
+  parse(ctx, &parser, args)?;
   drop(parser);
 
   subargs.insert(0, format!("nitrocli otp {}", subcommand));
@@ -685,7 +711,7 @@ fn otp_get(ctx: &mut ExecCtx<'_>, args: Vec<String>) -> Result<()> {
     argparse::StoreOption,
     "The time to use for TOTP generation (Unix timestamp, default: system time)",
   );
-  parse(&parser, args)?;
+  parse(ctx, &parser, args)?;
   drop(parser);
 
   commands::otp_get(ctx, slot, algorithm, time)
@@ -743,7 +769,7 @@ pub fn otp_set(ctx: &mut ExecCtx<'_>, args: Vec<String>) -> Result<()> {
     argparse::StoreTrue,
     "Interpret the given secret as an ASCII string of the secret",
   );
-  parse(&parser, args)?;
+  parse(ctx, &parser, args)?;
   drop(parser);
 
   let data = nitrokey::OtpSlotData {
@@ -773,7 +799,7 @@ fn otp_clear(ctx: &mut ExecCtx<'_>, args: Vec<String>) -> Result<()> {
     argparse::Store,
     "The OTP algorithm to use (hotp|totp)",
   );
-  parse(&parser, args)?;
+  parse(ctx, &parser, args)?;
   drop(parser);
 
   commands::otp_clear(ctx, slot, algorithm)
@@ -789,7 +815,7 @@ fn otp_status(ctx: &mut ExecCtx<'_>, args: Vec<String>) -> Result<()> {
     argparse::StoreTrue,
     "Show slots that are not programmed",
   );
-  parse(&parser, args)?;
+  parse(ctx, &parser, args)?;
   drop(parser);
 
   commands::otp_status(ctx, all)
@@ -812,7 +838,7 @@ fn pin(ctx: &mut ExecCtx<'_>, args: Vec<String>) -> Result<()> {
     "The arguments for the subcommand",
   );
   parser.stop_on_first_argument(true);
-  parse(&parser, args)?;
+  parse(ctx, &parser, args)?;
   drop(parser);
 
   subargs.insert(0, format!("nitrocli pin {}", subcommand));
@@ -820,10 +846,10 @@ fn pin(ctx: &mut ExecCtx<'_>, args: Vec<String>) -> Result<()> {
 }
 
 /// Clear the PIN as cached by various other commands.
-fn pin_clear(args: Vec<String>) -> Result<()> {
+fn pin_clear(ctx: &mut ExecCtx<'_>, args: Vec<String>) -> Result<()> {
   let mut parser = argparse::ArgumentParser::new();
   parser.set_description("Clears the cached PINs");
-  parse(&parser, args)?;
+  parse(ctx, &parser, args)?;
 
   commands::pin_clear()
 }
@@ -838,7 +864,7 @@ fn pin_set(ctx: &mut ExecCtx<'_>, args: Vec<String>) -> Result<()> {
     argparse::Store,
     "The PIN type to change (admin|user)",
   );
-  parse(&parser, args)?;
+  parse(ctx, &parser, args)?;
   drop(parser);
 
   commands::pin_set(ctx, pintype)
@@ -848,7 +874,7 @@ fn pin_set(ctx: &mut ExecCtx<'_>, args: Vec<String>) -> Result<()> {
 fn pin_unblock(ctx: &mut ExecCtx<'_>, args: Vec<String>) -> Result<()> {
   let mut parser = argparse::ArgumentParser::new();
   parser.set_description("Unblocks and resets the user PIN");
-  parse(&parser, args)?;
+  parse(ctx, &parser, args)?;
 
   commands::pin_unblock(ctx)
 }
@@ -870,7 +896,7 @@ fn pws(ctx: &mut ExecCtx<'_>, args: Vec<String>) -> Result<()> {
     "The arguments for the subcommand",
   );
   parser.stop_on_first_argument(true);
-  parse(&parser, args)?;
+  parse(ctx, &parser, args)?;
   drop(parser);
 
   subargs.insert(0, format!("nitrocli pws {}", subcommand));
@@ -911,7 +937,7 @@ fn pws_get(ctx: &mut ExecCtx<'_>, args: Vec<String>) -> Result<()> {
     argparse::StoreTrue,
     "Print the stored data without description",
   );
-  parse(&parser, args)?;
+  parse(ctx, &parser, args)?;
   drop(parser);
 
   commands::pws_get(ctx, slot, name, login, password, quiet)
@@ -945,7 +971,7 @@ fn pws_set(ctx: &mut ExecCtx<'_>, args: Vec<String>) -> Result<()> {
     argparse::Store,
     "The password to store on the slot",
   );
-  parse(&parser, args)?;
+  parse(ctx, &parser, args)?;
   drop(parser);
 
   commands::pws_set(ctx, slot, &name, &login, &password)
@@ -961,7 +987,7 @@ fn pws_clear(ctx: &mut ExecCtx<'_>, args: Vec<String>) -> Result<()> {
     argparse::Store,
     "The PWS slot to clear",
   );
-  parse(&parser, args)?;
+  parse(ctx, &parser, args)?;
   drop(parser);
 
   commands::pws_clear(ctx, slot)
@@ -977,7 +1003,7 @@ fn pws_status(ctx: &mut ExecCtx<'_>, args: Vec<String>) -> Result<()> {
     argparse::StoreTrue,
     "Show slots that are not programmed",
   );
-  parse(&parser, args)?;
+  parse(ctx, &parser, args)?;
   drop(parser);
 
   commands::pws_status(ctx, all)
@@ -985,7 +1011,11 @@ fn pws_status(ctx: &mut ExecCtx<'_>, args: Vec<String>) -> Result<()> {
 
 /// Parse the command-line arguments and return the selected command and
 /// the remaining arguments for the command.
-fn parse_arguments<'io>(args: Vec<String>) -> Result<(Command, ExecCtx<'io>, Vec<String>)> {
+fn parse_arguments<'io>(
+  args: Vec<String>,
+  stdout: &'io mut dyn io::Write,
+  stderr: &'io mut dyn io::Write,
+) -> Result<(Command, ExecCtx<'io>, Vec<String>)> {
   let mut model: Option<DeviceModel> = None;
   let mut verbosity = 0;
   let mut command = Command::Status;
@@ -1013,17 +1043,26 @@ fn parse_arguments<'io>(args: Vec<String>) -> Result<(Command, ExecCtx<'io>, Vec
     "The arguments for the command",
   );
   parser.stop_on_first_argument(true);
-  parse(&parser, args)?;
+  parse(&mut ParseCtx { stdout, stderr }, &parser, args)?;
   drop(parser);
 
   subargs.insert(0, format!("nitrocli {}", command));
 
-  let ctx = ExecCtx { model, verbosity, data: Default::default() };
+  let ctx = ExecCtx {
+    model,
+    stdout,
+    stderr,
+    verbosity,
+  };
   Ok((command, ctx, subargs))
 }
 
 /// Parse the command-line arguments and execute the selected command.
-pub fn handle_arguments(args: Vec<String>) -> Result<()> {
-  let (command, mut ctx, args) = parse_arguments(args)?;
+pub fn handle_arguments(
+  args: Vec<String>,
+  stdout: &mut dyn io::Write,
+  stderr: &mut dyn io::Write,
+) -> Result<()> {
+  let (command, mut ctx, args) = parse_arguments(args, stdout, stderr)?;
   command.execute(&mut ctx, args)
 }

--- a/nitrocli/src/error.rs
+++ b/nitrocli/src/error.rs
@@ -24,9 +24,16 @@ use std::string;
 #[derive(Debug)]
 pub enum Error {
   ArgparseError(i32),
+  CommandError(nitrokey::CommandError),
   IoError(io::Error),
   Utf8Error(string::FromUtf8Error),
   Error(String),
+}
+
+impl From<nitrokey::CommandError> for Error {
+  fn from(e: nitrokey::CommandError) -> Error {
+    Error::CommandError(e)
+  }
 }
 
 impl From<io::Error> for Error {
@@ -45,6 +52,7 @@ impl fmt::Display for Error {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     match *self {
       Error::ArgparseError(_) => write!(f, "Could not parse arguments"),
+      Error::CommandError(ref e) => write!(f, "Command error: {}", e),
       Error::Utf8Error(_) => write!(f, "Encountered UTF-8 conversion error"),
       Error::IoError(ref e) => write!(f, "IO error: {}", e.get_ref().unwrap()),
       Error::Error(ref e) => write!(f, "{}", e),

--- a/nitrocli/src/main.rs
+++ b/nitrocli/src/main.rs
@@ -72,6 +72,8 @@ mod args;
 mod commands;
 mod error;
 mod pinentry;
+#[cfg(test)]
+mod tests;
 
 use std::env;
 use std::io;

--- a/nitrocli/src/main.rs
+++ b/nitrocli/src/main.rs
@@ -73,6 +73,8 @@ mod commands;
 mod error;
 mod pinentry;
 
+use std::env;
+use std::io;
 use std::process;
 use std::result;
 
@@ -81,8 +83,8 @@ use crate::error::Error;
 type Result<T> = result::Result<T, Error>;
 
 fn run() -> i32 {
-  let args = std::env::args().collect();
-  match args::handle_arguments(args) {
+  let args = env::args().collect();
+  match args::handle_arguments(args, &mut io::stdout(), &mut io::stderr()) {
     Ok(()) => 0,
     Err(err) => match err {
       Error::ArgparseError(err) => match err {

--- a/nitrocli/src/tests.rs
+++ b/nitrocli/src/tests.rs
@@ -1,0 +1,132 @@
+// tests.rs
+
+// *************************************************************************
+// * Copyright (C) 2019 Daniel Mueller (deso@posteo.net)                   *
+// *                                                                       *
+// * This program is free software: you can redistribute it and/or modify  *
+// * it under the terms of the GNU General Public License as published by  *
+// * the Free Software Foundation, either version 3 of the License, or     *
+// * (at your option) any later version.                                   *
+// *                                                                       *
+// * This program is distributed in the hope that it will be useful,       *
+// * but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+// * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+// * GNU General Public License for more details.                          *
+// *                                                                       *
+// * You should have received a copy of the GNU General Public License     *
+// * along with this program.  If not, see <http://www.gnu.org/licenses/>. *
+// *************************************************************************
+
+use nitrokey_test::test as test_device;
+
+trait IntoArg {
+  fn into_arg(self) -> &'static str;
+}
+
+impl IntoArg for nitrokey::Pro {
+  fn into_arg(self) -> &'static str {
+    "--model=pro"
+  }
+}
+
+impl IntoArg for nitrokey::Storage {
+  fn into_arg(self) -> &'static str {
+    "--model=storage"
+  }
+}
+
+impl IntoArg for nitrokey::DeviceWrapper {
+  fn into_arg(self) -> &'static str {
+    match self {
+      nitrokey::DeviceWrapper::Pro(x) => x.into_arg(),
+      nitrokey::DeviceWrapper::Storage(x) => x.into_arg(),
+    }
+  }
+}
+
+impl IntoArg for &'static str {
+  fn into_arg(self) -> &'static str {
+    self
+  }
+}
+
+/// Run `nitrocli` with the given set of arguments.
+fn nitrocli<D>(device: D, args: &[&'static str]) -> crate::Result<Vec<u8>>
+where
+  D: IntoArg,
+{
+  let args = ["nitrocli", device.into_arg()]
+    .into_iter()
+    .chain(args)
+    .cloned()
+    .map(|x| x.to_owned())
+    .collect();
+
+  let mut stdout = Vec::new();
+  let mut stderr = Vec::new();
+
+  crate::args::handle_arguments(args, &mut stdout, &mut stderr).map(|_| stdout)
+}
+
+static SECRET: &'static str = "3132333435363738393031323334353637383930";
+
+#[test_device]
+fn totp_no_pin(device: nitrokey::DeviceWrapper) -> crate::Result<()> {
+  let device = device.into_arg();
+  // TODO: This call can potentially ask for the admin PIN which makes it
+  //       interactive and unacceptable.
+  let _ = nitrocli(device, &["config", "set", "--no-otp-pin"])?;
+
+  let slot = "0";
+  let name = "test-totp";
+
+  let _ = nitrocli(
+    device,
+    &["otp", "set", slot, name, SECRET, "--algorithm", "totp"],
+  )?;
+
+  let output = nitrocli(
+    device,
+    &[
+      "otp",
+      "get",
+      slot,
+      "--algorithm",
+      "totp",
+      "--time",
+      "1111111111",
+    ],
+  )?;
+  assert_eq!(output, b"050471\n");
+
+  let _ = nitrocli(
+    device,
+    &[
+      "otp",
+      "set",
+      slot,
+      name,
+      SECRET,
+      "--algorithm",
+      "totp",
+      "--digits",
+      "8",
+    ],
+  )?;
+
+  let output = nitrocli(
+    device,
+    &[
+      "otp",
+      "get",
+      slot,
+      "--algorithm",
+      "totp",
+      "--time",
+      "1111111111",
+    ],
+  )?;
+  assert_eq!(output, b"14050471\n");
+
+  Ok(())
+}


### PR DESCRIPTION
This pull request introduces the first device driven test for the program. It comprises three changes that enable us to effectively invoke the program's main function (that is in contrast to running `nitrocli` as part of a separate process; see the description of the second change for more details), supplying the desired arguments as well as buffers for stdout and stderr.

The fourth change adds the first actual test. We use the `nitrokey-test` crate to automatically serialize tests and run them only on present devices. (the test will probably not go in as-is, for there is a TODO that needs to be resolved first, but it shows the workings very well)