### PR TITLE
Add first set of integration tests

### DIFF
--- a/nitrocli/Cargo.lock
+++ b/nitrocli/Cargo.lock
@@ -1,4 +1,12 @@
 [[package]]
+name = "aho-corasick"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "argparse"
 version = "0.2.2"
 
@@ -20,6 +28,11 @@ name = "cc"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 replace = "cc 1.0.28"
+
+[[package]]
+name = "cfg-if"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cloudabi"
@@ -44,6 +57,11 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "lazy_static"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "libc"
 version = "0.2.45"
 
@@ -54,6 +72,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 replace = "libc 0.2.45"
 
 [[package]]
+name = "memchr"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "nitrocli"
 version = "0.2.0"
 dependencies = [
@@ -61,6 +89,8 @@ dependencies = [
  "base32 0.4.0",
  "libc 0.2.45",
  "nitrokey 0.3.0",
+ "nitrokey-test 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -84,6 +114,32 @@ name = "nitrokey-sys"
 version = "3.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 replace = "nitrokey-sys 3.4.1"
+
+[[package]]
+name = "nitrokey-test"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.23 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "0.4.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "quote"
+version = "0.6.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "rand"
@@ -150,6 +206,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aho-corasick 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.2.3"
 dependencies = [
@@ -186,6 +262,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 replace = "semver-parser 0.7.0"
 
 [[package]]
+name = "syn"
+version = "0.15.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thread_local"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ucd-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unicode-xid"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "utf8-ranges"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "version_check"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "winapi"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -205,17 +319,32 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
+"checksum aho-corasick 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1e9a933f4e58658d7b12defcf96dc5c720f20832deebe3e0a19efd3b6aaeeb9e"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
 "checksum cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4a8b715cb4597106ea87c7c84b2f1d452c7492033765df7f32651e66fcf749"
+"checksum cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "082bb9b28e00d3c9d39cc03e64ce4cea0f1bb9b3fde493f0cbc008472d22bdf4"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
+"checksum lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a374c89b9db55895453a74c1e38861d9deec0b01b405a82516e9d5de4820dea1"
 "checksum libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)" = "2d2857ec59fadc0773853c664d2d18e7198e83883e7060b63c924cb077bd5c74"
+"checksum memchr 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "db4c41318937f6e76648f42826b1d9ade5c09cafb5aef7e351240a70f39206e9"
 "checksum nitrokey-sys 3.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "34794d630d40a093a3f0e31b821b38ee1c16e6909dc42064feff28f4798484f4"
+"checksum nitrokey-test 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6226eaa31d1bbb031314d9288eb0e1bf6a70e7053da7960fea13ee84cab330ea"
+"checksum proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)" = "77619697826f31a02ae974457af0b29b723e5619e113e9397b8b82c6bd253f09"
+"checksum quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "53fa22a1994bd0f9372d7a816207d8a2677ad0325b073f5c5332760f0fb62b5c"
 "checksum rand 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ae9d223d52ae411a33cf7e54ec6034ec165df296ccd23533d671a28252b6f66a"
+"checksum regex 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "37e7cbbd370869ce2e8dff25c7018702d10b21a20ef7135316f8daecd6c25b7f"
+"checksum regex-syntax 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4e47a2ed29da7a9e1960e1639e7a982e6edc6d49be308a3b02daf511504a16d1"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+"checksum syn 0.15.23 (registry+https://github.com/rust-lang/crates.io-index)" = "9545a6a093a3f0bd59adb472700acc08cad3776f860f16a897dfce8c88721cbc"
+"checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
+"checksum ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "535c204ee4d8434478593480b8f86ab45ec9aae0e83c568ca81abf0fd0e88f86"
+"checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
+"checksum utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "796f7e48bef87609f7ade7e06495a87d5cd06c7866e6a5cbfceffc558a243737"
+"checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/nitrocli/Cargo.toml
+++ b/nitrocli/Cargo.toml
@@ -57,6 +57,11 @@ path = "../libc"
 version = "0.3"
 path = "../nitrokey"
 
+[dev-dependencies.nitrokey-test]
+version = "0.1.1"
+
+[dev-dependencies.regex]
+version = "1"
 
 [replace]
 "base32:0.4.0" = { path = "../base32" }

--- a/nitrocli/src/main.rs
+++ b/nitrocli/src/main.rs
@@ -75,6 +75,8 @@ mod args;
 mod commands;
 mod error;
 mod pinentry;
+#[cfg(test)]
+mod tests;
 
 use std::env;
 use std::io;
@@ -93,7 +95,7 @@ pub(crate) struct RunCtx<'io> {
   pub stderr: &'io mut dyn io::Write,
 }
 
-fn run<'io, 'ctx: 'io>(ctx: &'ctx mut RunCtx<'io>, args: Vec<String>) -> i32 {
+fn run<'ctx, 'io: 'ctx>(ctx: &'ctx mut RunCtx<'io>, args: Vec<String>) -> i32 {
   match args::handle_arguments(ctx, args) {
     Ok(()) => 0,
     Err(err) => match err {

--- a/nitrocli/src/tests/mod.rs
+++ b/nitrocli/src/tests/mod.rs
@@ -1,0 +1,113 @@
+// tests.rs
+
+// *************************************************************************
+// * Copyright (C) 2019 Daniel Mueller (deso@posteo.net)                   *
+// *                                                                       *
+// * This program is free software: you can redistribute it and/or modify  *
+// * it under the terms of the GNU General Public License as published by  *
+// * the Free Software Foundation, either version 3 of the License, or     *
+// * (at your option) any later version.                                   *
+// *                                                                       *
+// * This program is distributed in the hope that it will be useful,       *
+// * but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+// * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+// * GNU General Public License for more details.                          *
+// *                                                                       *
+// * You should have received a copy of the GNU General Public License     *
+// * along with this program.  If not, see <http://www.gnu.org/licenses/>. *
+// *************************************************************************
+
+use nitrokey_test::test as test_device;
+
+// TODO: This is a hack to make the nitrokey-test crate work across
+//       module boundaries. Upon first use of the nitrokey_test::test
+//       macro a new function, __nitrokey_mutex, will be emitted, but it
+//       is not visible in a different module. To work around that we
+//       trigger the macro here first and then `use super::*` from all
+//       of the submodules.
+#[test_device]
+fn dummy() {}
+
+mod run;
+mod status;
+
+/// An `Option<IntoArg>` that represents a non-present device. Rust can
+/// be notoriously bad at inferring type parameters and this constant
+/// alleviates the pain.
+const NO_DEV: Option<nitrokey::Pro> = None;
+
+/// A trait for conversion of a nitrokey::Device into an argument
+/// representing the device model that the program recognizes.
+pub trait IntoArg {
+  fn into_arg(self) -> &'static str;
+}
+
+impl IntoArg for nitrokey::Pro {
+  fn into_arg(self) -> &'static str {
+    "--model=pro"
+  }
+}
+
+impl IntoArg for nitrokey::Storage {
+  fn into_arg(self) -> &'static str {
+    "--model=storage"
+  }
+}
+
+impl IntoArg for nitrokey::DeviceWrapper {
+  fn into_arg(self) -> &'static str {
+    match self {
+      nitrokey::DeviceWrapper::Pro(x) => x.into_arg(),
+      nitrokey::DeviceWrapper::Storage(x) => x.into_arg(),
+    }
+  }
+}
+
+mod nitrocli {
+  use super::*;
+
+  use crate::args;
+  use crate::Result;
+  use crate::RunCtx;
+
+  fn do_run<F, R, I>(device: Option<I>, args: &[&'static str], f: F) -> (R, Vec<u8>, Vec<u8>)
+  where
+    F: FnOnce(&mut RunCtx<'_>, Vec<String>) -> R,
+    I: IntoArg,
+  {
+    let args = ["nitrocli"]
+      .into_iter()
+      .cloned()
+      .chain(device.into_iter().map(IntoArg::into_arg))
+      .chain(args.into_iter().cloned())
+      .map(ToOwned::to_owned)
+      .collect();
+
+    let mut stdout = Vec::new();
+    let mut stderr = Vec::new();
+
+    let ctx = &mut RunCtx {
+      stdout: &mut stdout,
+      stderr: &mut stderr,
+    };
+
+    (f(ctx, args), stdout, stderr)
+  }
+
+  /// Run `nitrocli`'s `run` function.
+  pub fn run<I>(device: Option<I>, args: &[&'static str]) -> (i32, Vec<u8>, Vec<u8>)
+  where
+    I: IntoArg,
+  {
+    do_run(device, args, |c, a| crate::run(c, a))
+  }
+
+  /// Run `nitrocli`'s `handle_arguments` function.
+  pub fn handle<I>(device: Option<I>, args: &[&'static str]) -> Result<String>
+  where
+    I: IntoArg,
+  {
+    let (res, out, _) = do_run(device, args, |c, a| args::handle_arguments(c, a));
+    res.map(|_| String::from_utf8_lossy(&out).into_owned())
+  }
+}


### PR DESCRIPTION
This change introduces the first set of integration-style test for the
application. Those tests may or may not connect to an actual Nitrokey
device (depending on what they test). We use the nitrokey-test crate's
test attribute macro to automatically dispatch tests to connected
devices or skip them if a required device is not present. It also
provides the means for automatically serializing tests.