### PR TITLE
Refactor get_device to use nitrokey::connect_model

### DIFF
--- a/nitrocli/src/args.rs
+++ b/nitrocli/src/args.rs
@@ -59,6 +59,15 @@ Enum! {DeviceModel, [
   Storage => "storage"
 ]}
 
+impl From<DeviceModel> for nitrokey::Model {
+  fn from(model: DeviceModel) -> nitrokey::Model {
+    match model {
+      DeviceModel::Pro => nitrokey::Model::Pro,
+      DeviceModel::Storage => nitrokey::Model::Storage,
+    }
+  }
+}
+
 /// A top-level command for nitrocli.
 Enum! {Command, [
   Config => "config",

--- a/nitrocli/src/commands.rs
+++ b/nitrocli/src/commands.rs
@@ -59,12 +59,7 @@ fn get_device(ctx: &mut args::ExecCtx<'_>) -> Result<nitrokey::DeviceWrapper> {
   set_log_level(ctx);
 
   match ctx.model {
-    Some(model) => match model {
-      args::DeviceModel::Pro => nitrokey::Pro::connect().map(nitrokey::DeviceWrapper::Pro),
-      args::DeviceModel::Storage => {
-        nitrokey::Storage::connect().map(nitrokey::DeviceWrapper::Storage)
-      }
-    },
+    Some(model) => nitrokey::connect_model(model.into()),
     None => nitrokey::connect(),
   }
   .map_err(|_| Error::Error("Nitrokey device not found".to_string()))


### PR DESCRIPTION
nitrokey 0.3.1 introduced the connect_model function that connects to a
specific model given by an enum variant and returns a DeviceWrapper.
This new function allows us to remove the manual selection of a
connection method from the `get_device` function.  We only have to
implement From<DeviceModel> for nitrokey::Model to be able to convert
our model enum to nitrokey’s model enum.