### PR TITLE
Implement From<&str> for Error

### DIFF
--- a/nitrocli/src/args.rs
+++ b/nitrocli/src/args.rs
@@ -525,8 +525,8 @@ pub fn otp_set(ctx: &mut ExecCtx<'_>, args: Vec<String>) -> Result<()> {
 
   if ascii {
     if secret_format.is_some() {
-      return Err(Error::Error(
-        "The --format and the --ascii option cannot be used at the same time".to_string(),
+      return Err(Error::from(
+        "The --format and the --ascii option cannot be used at the same time",
       ));
     }
 

--- a/nitrocli/src/commands.rs
+++ b/nitrocli/src/commands.rs
@@ -67,7 +67,7 @@ fn get_device(ctx: &mut args::ExecCtx<'_>) -> Result<nitrokey::DeviceWrapper> {
     },
     None => nitrokey::connect(),
   }
-  .map_err(|_| Error::Error("Nitrokey device not found".to_string()))
+  .map_err(|_| Error::from("Nitrokey device not found"))
 }
 
 /// Connect to a Nitrokey Storage device and return it.
@@ -76,17 +76,13 @@ fn get_storage_device(ctx: &mut args::ExecCtx<'_>) -> Result<nitrokey::Storage> 
 
   if let Some(model) = ctx.model {
     if model != args::DeviceModel::Storage {
-      return Err(Error::Error(
-        "This command is only available on the Nitrokey Storage".to_string(),
+      return Err(Error::from(
+        "This command is only available on the Nitrokey Storage",
       ));
     }
   }
 
-  nitrokey::Storage::connect().or_else(|_| {
-    Err(Error::Error(
-      "Nitrokey Storage device not found".to_string(),
-    ))
-  })
+  nitrokey::Storage::connect().or_else(|_| Err(Error::from("Nitrokey Storage device not found")))
 }
 
 /// Open the password safe on the given device.
@@ -387,11 +383,7 @@ fn get_otp<T: GenerateOtp>(slot: u8, algorithm: args::OtpAlgorithm, device: &T) 
 fn get_unix_timestamp() -> Result<u64> {
   time::SystemTime::now()
     .duration_since(time::UNIX_EPOCH)
-    .or_else(|_| {
-      Err(Error::Error(
-        "Current system time is before the Unix epoch".to_string(),
-      ))
-    })
+    .or_else(|_| Err(Error::from("Current system time is before the Unix epoch")))
     .map(|duration| duration.as_secs())
 }
 
@@ -445,8 +437,8 @@ fn prepare_ascii_secret(secret: &str) -> Result<String> {
   if secret.is_ascii() {
     Ok(format_bytes(&secret.as_bytes()))
   } else {
-    Err(Error::Error(
-      "The given secret is not an ASCII string despite --format ascii being set".to_string(),
+    Err(Error::from(
+      "The given secret is not an ASCII string despite --format ascii being set",
     ))
   }
 }
@@ -455,7 +447,7 @@ fn prepare_ascii_secret(secret: &str) -> Result<String> {
 fn prepare_base32_secret(secret: &str) -> Result<String> {
   base32::decode(base32::Alphabet::RFC4648 { padding: false }, secret)
     .map(|vec| format_bytes(&vec))
-    .ok_or_else(|| Error::Error("Could not parse base32 secret".to_string()))
+    .ok_or_else(|| Error::from("Could not parse base32 secret"))
 }
 
 /// Configure a one-time password slot on the Nitrokey device.
@@ -512,9 +504,7 @@ fn print_otp_status(
     slot = match slot.checked_add(1) {
       Some(slot) => slot,
       None => {
-        return Err(Error::Error(
-          "Integer overflow when iterating OTP slots".to_string(),
-        ))
+        return Err(Error::from("Integer overflow when iterating OTP slots"));
       }
     };
     let name = match result {
@@ -574,7 +564,7 @@ fn choose_pin(pin_type: pinentry::PinType) -> Result<String> {
   pinentry::clear_pin(pin_type)?;
 
   if new_pin != confirm_pin {
-    Err(Error::Error("Entered PINs do not match".to_string()))
+    Err(Error::from("Entered PINs do not match"))
   } else {
     Ok(new_pin)
   }
@@ -675,7 +665,7 @@ fn print_pws_slot(
   programmed: bool,
 ) -> Result<()> {
   if slot > u8::MAX as usize {
-    return Err(Error::Error("Invalid PWS slot number".to_string()));
+    return Err(Error::from("Invalid PWS slot number"));
   }
   let slot = slot as u8;
   let name = if programmed {

--- a/nitrocli/src/error.rs
+++ b/nitrocli/src/error.rs
@@ -31,6 +31,12 @@ pub enum Error {
   Error(String),
 }
 
+impl From<&str> for Error {
+  fn from(s: &str) -> Error {
+    Error::Error(s.to_string())
+  }
+}
+
 impl From<nitrokey::CommandError> for Error {
   fn from(e: nitrokey::CommandError) -> Error {
     Error::CommandError(None, e)

--- a/nitrocli/src/pinentry.rs
+++ b/nitrocli/src/pinentry.rs
@@ -134,7 +134,7 @@ where
   // specially.
   if !lines.is_empty() && lines[0].starts_with("ERR ") {
     let (_, error) = lines[0].split_at(4);
-    return Err(Error::Error(error.to_string()));
+    return Err(Error::from(error));
   }
   Err(Error::Error(format!("Unexpected response: {}", string)))
 }


### PR DESCRIPTION
This patch implements From<&str> for Error so that we can use
Error::from(s) as a shorthand for Error::Error(s.to_string()).  It
also replaces Error::Error with Error::from where possible.