### PR TITLE
Add tests for otp command

### DIFF
--- a/nitrocli/src/args.rs
+++ b/nitrocli/src/args.rs
@@ -463,7 +463,7 @@ fn otp_get(ctx: &mut ExecCtx<'_>, args: Vec<String>) -> Result<()> {
   let _ = parser.refer(&mut algorithm).add_option(
     &["-a", "--algorithm"],
     argparse::Store,
-    "The OTP algorithm to use (hotp|totp)",
+    "The OTP algorithm to use (hotp|totp, default: totp)",
   );
   let _ = parser.refer(&mut time).add_option(
     &["-t", "--time"],
@@ -497,7 +497,7 @@ pub fn otp_set(ctx: &mut ExecCtx<'_>, args: Vec<String>) -> Result<()> {
   let _ = parser.refer(&mut algorithm).add_option(
     &["-a", "--algorithm"],
     argparse::Store,
-    "The OTP algorithm to use (hotp or totp, default: totp)",
+    "The OTP algorithm to use (hotp|totp, default: totp)",
   );
   let _ = parser.refer(&mut name).required().add_argument(
     "name",
@@ -577,7 +577,7 @@ fn otp_clear(ctx: &mut ExecCtx<'_>, args: Vec<String>) -> Result<()> {
   let _ = parser.refer(&mut algorithm).add_option(
     &["-a", "--algorithm"],
     argparse::Store,
-    "The OTP algorithm to use (hotp|totp)",
+    "The OTP algorithm to use (hotp|totp, default: totp)",
   );
   parse(ctx, &parser, args)?;
   drop(parser);


### PR DESCRIPTION
This change adds a set of tests for the otp command. We cover some
variants of the status, set, get, and clear. Testing all the possible
combinations is out of scope and so only a more or less arbitrary subset
of arguments was chosen.

@robinkrahl , interested in reviewing?