### PR TITLE
Add support for hidden volumes

### DIFF
--- a/nitrocli/src/tests/lock.rs
+++ b/nitrocli/src/tests/lock.rs
@@ -1,0 +1,43 @@
+// lock.rs
+
+// *************************************************************************
+// * Copyright (C) 2019 Daniel Mueller (deso@posteo.net)                   *
+// *                                                                       *
+// * This program is free software: you can redistribute it and/or modify  *
+// * it under the terms of the GNU General Public License as published by  *
+// * the Free Software Foundation, either version 3 of the License, or     *
+// * (at your option) any later version.                                   *
+// *                                                                       *
+// * This program is distributed in the hope that it will be useful,       *
+// * but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+// * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+// * GNU General Public License for more details.                          *
+// *                                                                       *
+// * You should have received a copy of the GNU General Public License     *
+// * along with this program.  If not, see <http://www.gnu.org/licenses/>. *
+// *************************************************************************
+
+use super::*;
+
+#[test_device]
+fn lock_pro(device: nitrokey::Pro) -> crate::Result<()> {
+  // We can't really test much more here than just success of the command.
+  let out = Nitrocli::with_dev(device).handle(&["lock"])?;
+  assert!(out.is_empty());
+
+  Ok(())
+}
+
+#[test_device]
+fn lock_storage(device: nitrokey::Storage) -> crate::Result<()> {
+  let mut ncli = Nitrocli::with_dev(device);
+  let _ = ncli.handle(&["storage", "open"])?;
+
+  let out = ncli.handle(&["lock"])?;
+  assert!(out.is_empty());
+
+  let device = nitrokey::Storage::connect()?;
+  assert!(!device.get_status()?.encrypted_volume.active);
+
+  Ok(())
+}

--- a/nitrocli/src/tests/mod.rs
+++ b/nitrocli/src/tests/mod.rs
@@ -37,6 +37,7 @@ const NITROKEY_DEFAULT_USER_PIN: &str = "123456";
 fn dummy() {}
 
 mod config;
+mod lock;
 mod otp;
 mod pin;
 mod pws;


### PR DESCRIPTION
This patch set introduces support for hidden volumes to the program. Management of those volumes is controlled through the newly introduced `storage hidden` subcommand. Hidden volumes can be created, opened, and closed.

---

@robinkrahl, are you interested in reviewing those changes?