### PR TITLE
Exclude CI scripts and rustmft config

### DIFF
--- a/nitrocli/Cargo.toml
+++ b/nitrocli/Cargo.toml
@@ -31,6 +31,7 @@ keywords = ["nitrokey", "nitrokey-storage", "nitrokey-pro", "cli", "usb"]
 description = """
 A command line tool for interacting with the Nitrokey Storage device.
 """
+exclude = ["ci/*", "rustfmt.toml"]
 
 [badges]
 gitlab = { repository = "d-e-s-o/nitrocli", branch = "master" }


### PR DESCRIPTION
The CI scripts and the rustfmt configuration are only needed when
developing.  There is no point in distributing them in the package
published on crates.io, so we exclude them from packaging using the
exclude setting in Cargo.toml.