### PR TITLE
Check PWS slot status before accessng it

### DIFF
--- a/nitrocli/CHANGELOG.md
+++ b/nitrocli/CHANGELOG.md
@@ -5,6 +5,7 @@ Unreleased
 - Added the `reset` command to perform a factory reset
 - Store cached PINs on a per-device basis to better support multi-device
   scenarios
+- Check the status of a PWS slot before accesing it in `pws get`
 - Further decrease binary size by using system allocator
 - Bumped `nitrokey` dependency to `0.3.4`
   - Bumped `rand` dependency to `0.6.4`

--- a/nitrocli/src/commands.rs
+++ b/nitrocli/src/commands.rs
@@ -757,6 +757,23 @@ fn print_pws_data(
   Ok(())
 }
 
+fn check_slot(pws: &nitrokey::PasswordSafe<'_>, slot: u8) -> Result<()> {
+  if slot >= nitrokey::SLOT_COUNT {
+    return Err(nitrokey::CommandError::InvalidSlot.into());
+  }
+  let status = pws
+    .get_slot_status()
+    .map_err(|err| get_error("Could not read PWS slot status", err))?;
+  if status[slot as usize] {
+    Ok(())
+  } else {
+    Err(get_error(
+      "Could not access PWS slot",
+      nitrokey::CommandError::SlotNotProgrammed,
+    ))
+  }
+}
+
 /// Read a PWS slot.
 pub fn pws_get(
   ctx: &mut args::ExecCtx<'_>,
@@ -768,6 +785,7 @@ pub fn pws_get(
 ) -> Result<()> {
   let device = get_device(ctx)?;
   let pws = get_password_safe(ctx, &device)?;
+  check_slot(&pws, slot)?;
   let show_all = !show_name && !show_login && !show_password;
   if show_all || show_name {
     print_pws_data(ctx, "name:    ", pws.get_slot_name(slot), quiet)?;

--- a/nitrocli/src/tests/pws.rs
+++ b/nitrocli/src/tests/pws.rs
@@ -83,6 +83,29 @@ fn set_get(device: nitrokey::DeviceWrapper) -> crate::Result<()> {
 }
 
 #[test_device]
+fn set_reset_get(device: nitrokey::DeviceWrapper) -> crate::Result<()> {
+  const NAME: &str = "dropbox";
+  const LOGIN: &str = "d-e-s-o";
+  const PASSWORD: &str = "my-secret-password";
+
+  let mut ncli = Nitrocli::with_dev(device);
+  let _ = ncli.handle(&["pws", "set", "1", &NAME, &LOGIN, &PASSWORD])?;
+
+  let out = ncli.handle(&["reset"])?;
+  assert_eq!(out, "");
+
+  let res = ncli.handle(&["pws", "get", "1"]);
+  assert_eq!(
+    res.unwrap_cmd_err(),
+    (
+      Some("Could not access PWS slot"),
+      nitrokey::CommandError::SlotNotProgrammed
+    )
+  );
+  Ok(())
+}
+
+#[test_device]
 fn clear(device: nitrokey::DeviceWrapper) -> crate::Result<()> {
   let mut ncli = Nitrocli::with_dev(device);
   let _ = ncli.handle(&["pws", "set", "10", "clear-test", "some-login", "abcdef"])?;


### PR DESCRIPTION
The Nitrokey devices to not check whether a PWS slot is programmed
before accessing it (upstream issues [0] [1]).  Until this is fixed in
the firmware, we have to manually check the slot status in nitrocli pws
get.  This could have been done in libnitrokey or the nitrokey crate,
yet this would lead to unnecessary commands if we check multiple fields
of a slot at the same time.

[0] https://github.com/Nitrokey/nitrokey-pro-firmware/issues/56
[1] https://github.com/Nitrokey/nitrokey-storage-firmware/issues/81