### PR TITLE
Respect ctx.std{out,err} for version output

### DIFF
--- a/nitrocli/src/tests/run.rs
+++ b/nitrocli/src/tests/run.rs
@@ -45,3 +45,22 @@ fn help_option() {
   test("--help");
   test("-h")
 }
+
+#[test]
+fn version_option() {
+  fn test(re: &regex::Regex, opt: &'static str) {
+    let (rc, out, err) = Nitrocli::new().run(&[opt]);
+
+    assert_eq!(rc, 0);
+    assert_eq!(err, b"");
+
+    let s = String::from_utf8_lossy(&out).into_owned();
+    let _ = re;
+    assert!(re.is_match(&s), out);
+  }
+
+  let re = regex::Regex::new(r"^nitrocli \d+.\d+.\d+(-[^-]+)*$").unwrap();
+
+  test(&re, "--version");
+  test(&re, "-V");
+}


### PR DESCRIPTION
Due to a bug in argparse [0], custom stdout and stderr settings are ignored
when using argparse::Print, as we currently do for the --version option. 
This patch adds a workaround for this problem:  Instead of using
argparse::Print, we use argparse::StoreTrue for the --version option.

The argument parsing will fail as the command is missing, but the version
variable will still be set to true if the version option was set.  So we
ignore the parsing result and discard the argparse output if the version
variable is set.

[0] https://github.com/tailhook/rust-argparse/pull/50