### PR TITLE
Make --verbose and --model options global

### DIFF
--- a/nitrocli/CHANGELOG.md
+++ b/nitrocli/CHANGELOG.md
@@ -5,6 +5,7 @@ Unreleased
   - Added `structopt` dependency in version `0.3.7`
   - Replaced `argparse` with `structopt`
   - Removed the `argparse` dependency
+  - Made the --verbose and --model options global
 - Bumped `nitrokey` dependency to `0.5.1`
 
 

--- a/nitrocli/src/args.rs
+++ b/nitrocli/src/args.rs
@@ -74,10 +74,10 @@ impl<'io> Stdio for ExecCtx<'io> {
 #[structopt(name = "nitrocli")]
 struct Args {
   /// Increases the log level (can be supplied multiple times)
-  #[structopt(short, long, parse(from_occurrences))]
+  #[structopt(short, long, global = true, parse(from_occurrences))]
   verbose: u8,
   /// Selects the device model to connect to
-  #[structopt(short, long, possible_values = &DeviceModel::all_str())]
+  #[structopt(short, long, global = true, possible_values = &DeviceModel::all_str())]
   model: Option<DeviceModel>,
   #[structopt(subcommand)]
   cmd: Command,


### PR DESCRIPTION
This patch adds the attribute `global = true` for the top-level
--verbose and --model options, which ensures that they can also be set
for subcommands.  For example:
    nitrocli status --model pro
Instead of only:
    nitrocli --model pro status