### PR TITLE
Update nitrokey dependency to 0.6.0

### DIFF
--- a/nitrocli/CHANGELOG.md
+++ b/nitrocli/CHANGELOG.md
@@ -6,7 +6,7 @@ Unreleased
   - Replaced `argparse` with `structopt`
   - Removed the `argparse` dependency
   - Made the --verbose and --model options global
-- Bumped `nitrokey` dependency to `0.5.1`
+- Bumped `nitrokey` dependency to `0.6.0`
 
 
 0.3.1

--- a/nitrocli/Cargo.lock
+++ b/nitrocli/Cargo.lock
@@ -68,7 +68,7 @@ version = "0.3.1"
 dependencies = [
  "base32 0.4.0",
  "libc 0.2.66",
- "nitrokey 0.5.1",
+ "nitrokey 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "nitrokey-test 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "nitrokey-test-state 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -77,7 +77,8 @@ dependencies = [
 
 [[package]]
 name = "nitrokey"
-version = "0.5.1"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.4.0",
  "libc 0.2.66",
@@ -247,6 +248,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [metadata]
 "checksum aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d"
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
+"checksum nitrokey 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1587c61144935958f74fb9111c9a369a23a2e5ad39476bde1750b7b8c0c87ac0"
 "checksum nitrokey-test 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f3da0c2cedaa512f79fbc3ed45143a52c76c5edcca88d0823b967ff11d05fe37"
 "checksum nitrokey-test-state 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a59b732ed6d5212424ed31ec9649f05652bcbc38f45f2292b27a6044e7098803"
 "checksum regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dc220bd33bdce8f093101afe22a037b8eb0e5af33592e6a9caafff0d4cb81cbd"

--- a/nitrocli/Cargo.toml
+++ b/nitrocli/Cargo.toml
@@ -49,7 +49,7 @@ version = "0.4.0"
 version = "0.2"
 
 [dependencies.nitrokey]
-version = "0.5.1"
+version = "0.6"
 
 [dependencies.structopt]
 version = "0.3.7"
@@ -74,7 +74,6 @@ getrandom = { path = "../getrandom" }
 heck = { path = "../heck" }
 lazy_static = { path = "../lazy-static" }
 libc = { path = "../libc" }
-nitrokey = { path = "../nitrokey" }
 nitrokey-sys = { path = "../nitrokey-sys" }
 proc-macro-error = { path = "../proc-macro-error/proc-macro-error" }
 proc-macro-error-attr = { path = "../proc-macro-error/proc-macro-error-attr" }

--- a/nitrocli/src/commands.rs
+++ b/nitrocli/src/commands.rs
@@ -343,7 +343,7 @@ fn print_status(
     ctx,
     r#"Status:
   model:             {model}
-  serial number:     0x{id}
+  serial number:     {id}
   firmware version:  {fwv}
   user retry count:  {urc}
   admin retry count: {arc}"#,
@@ -393,7 +393,7 @@ pub fn list(ctx: &mut args::ExecCtx<'_>, no_connect: bool) -> Result<()> {
         .map(|m| m.to_string())
         .unwrap_or_else(|| "unknown".into());
       let serial_number = match device_info.serial_number {
-        Some(serial_number) => format!("0x{}", serial_number),
+        Some(serial_number) => serial_number.to_string(),
         None => {
           // Storage devices do not have the serial number present in
           // the device information. We have to connect to them to
@@ -402,7 +402,7 @@ pub fn list(ctx: &mut args::ExecCtx<'_>, no_connect: bool) -> Result<()> {
             "N/A".to_string()
           } else {
             let device = manager.connect_path(device_info.path.clone())?;
-            format!("0x{}", device.get_serial_number()?)
+            device.get_serial_number()?.to_string()
           }
         }
       };

--- a/nitrocli/src/pinentry.rs
+++ b/nitrocli/src/pinentry.rs
@@ -54,7 +54,7 @@ pub trait SecretEntry: fmt::Debug {
 pub struct PinEntry {
   pin_type: PinType,
   model: nitrokey::Model,
-  serial: String,
+  serial: nitrokey::SerialNumber,
 }
 
 impl PinEntry {
@@ -79,7 +79,8 @@ impl PinEntry {
 impl SecretEntry for PinEntry {
   fn cache_id(&self) -> Option<CowStr> {
     let model = self.model.to_string().to_lowercase();
-    let suffix = format!("{}:{}", model, self.serial);
+    // TODO: directly format serial instead?
+    let suffix = format!("{}:{:08x}", model, self.serial.as_u32());
     let cache_id = match self.pin_type {
       PinType::Admin => format!("nitrocli:admin:{}", suffix),
       PinType::User => format!("nitrocli:user:{}", suffix),
@@ -127,7 +128,7 @@ impl SecretEntry for PinEntry {
 #[derive(Debug)]
 pub struct PwdEntry {
   model: nitrokey::Model,
-  serial: String,
+  serial: nitrokey::SerialNumber,
 }
 
 impl PwdEntry {


### PR DESCRIPTION
nitrokey 0.6.0 introduced the SerialNumber struct (instead of
representing serial numbers as strings).  We no longer have to manually
format the serial number as SerialNumber implements Display.

For consistency, we keep the old formatting for the cache ID used by
pinentry.
TODO: should we use the new format instead?