### PR TITLE
Add support for generating a bash completion script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Unreleased
   - Replaced `argparse` with `structopt`
   - Removed `argparse` dependency
   - Made the --verbose and --model options global
+- Added bash completion support via `shell-complete` utility program
 - Removed vendored dependencies and moved source code into repository
   root
 - Bumped `nitrokey` dependency to `0.6.0`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,10 @@ exclude = ["ci/*", "rustfmt.toml"]
 [badges]
 gitlab = { repository = "d-e-s-o/nitrocli", branch = "master" }
 
+[[bin]]
+name = "shell-complete"
+path = "var/shell-complete.rs"
+
 [profile.release]
 opt-level = "z"
 lto = true

--- a/README.md
+++ b/README.md
@@ -112,6 +112,20 @@ It is recommended that the resulting executable be installed in a
 directory accessible via the `PATH` environment variable.
 
 
+#### Bash Completion
+**nitrocli** comes with Bash completion support for options and
+arguments to them. A completion script can be generated via the
+`shell-complete` utility program and then only needs to be sourced to
+make the current shell provide context-sensitive tab completion support.
+```bash
+$ cargo run --bin=shell-complete > nitrocli.bash
+$ source nitrocli.bash
+```
+
+The generated completion script can be installed system-wide as usual
+and sourced through Bash initialization files, such as `~/.bashrc`.
+
+
 Known Problems
 --------------
 

--- a/src/arg_defs.rs
+++ b/src/arg_defs.rs
@@ -17,9 +17,6 @@
 // * along with this program.  If not, see <http://www.gnu.org/licenses/>. *
 // *************************************************************************
 
-use crate::args;
-use crate::commands;
-
 /// Provides access to a Nitrokey device
 #[derive(structopt::StructOpt)]
 #[structopt(name = "nitrocli")]
@@ -69,9 +66,9 @@ Command! {Command, [
   /// Interacts with the device's hidden volume
   Hidden(HiddenArgs) => |ctx, args: HiddenArgs| args.subcmd.execute(ctx),
   /// Lists the attached Nitrokey devices
-  List(ListArgs) => |ctx, args: ListArgs| commands::list(ctx, args.no_connect),
+  List(ListArgs) => |ctx, args: ListArgs| crate::commands::list(ctx, args.no_connect),
   /// Locks the connected Nitrokey device
-  Lock => commands::lock,
+  Lock => crate::commands::lock,
   /// Accesses one-time passwords
   Otp(OtpArgs) => |ctx, args: OtpArgs| args.subcmd.execute(ctx),
   /// Manages the Nitrokey PINs
@@ -79,9 +76,9 @@ Command! {Command, [
   /// Accesses the password safe
   Pws(PwsArgs) => |ctx, args: PwsArgs| args.subcmd.execute(ctx),
   /// Performs a factory reset
-  Reset => commands::reset,
+  Reset => crate::commands::reset,
   /// Prints the status of the connected Nitrokey device
-  Status => commands::status,
+  Status => crate::commands::status,
   /// Interacts with the device's unencrypted volume
   Unencrypted(UnencryptedArgs) => |ctx, args: UnencryptedArgs| args.subcmd.execute(ctx),
 ]}
@@ -94,9 +91,9 @@ pub struct ConfigArgs {
 
 Command! {ConfigCommand, [
   /// Prints the Nitrokey configuration
-  Get => commands::config_get,
+  Get => crate::commands::config_get,
   /// Changes the Nitrokey configuration
-  Set(ConfigSetArgs) => args::config_set,
+  Set(ConfigSetArgs) => crate::args::config_set,
 ]}
 
 #[derive(Debug, PartialEq, structopt::StructOpt)]
@@ -170,9 +167,9 @@ pub struct EncryptedArgs {
 
 Command! {EncryptedCommand, [
   /// Closes the encrypted volume on a Nitrokey Storage
-  Close => commands::encrypted_close,
+  Close => crate::commands::encrypted_close,
   /// Opens the encrypted volume on a Nitrokey Storage
-  Open => commands::encrypted_open,
+  Open => crate::commands::encrypted_open,
 ]}
 
 #[derive(Debug, PartialEq, structopt::StructOpt)]
@@ -183,13 +180,13 @@ pub struct HiddenArgs {
 
 Command! {HiddenCommand, [
   /// Closes the hidden volume on a Nitrokey Storage
-  Close => commands::hidden_close,
+  Close => crate::commands::hidden_close,
   /// Creates a hidden volume on a Nitrokey Storage
   Create(HiddenCreateArgs) => |ctx, args: HiddenCreateArgs| {
-    commands::hidden_create(ctx, args.slot, args.start, args.end)
+    crate::commands::hidden_create(ctx, args.slot, args.start, args.end)
   },
   /// Opens the hidden volume on a Nitrokey Storage
-  Open => commands::hidden_open,
+  Open => crate::commands::hidden_open,
 ]}
 
 #[derive(Debug, PartialEq, structopt::StructOpt)]
@@ -218,16 +215,16 @@ pub struct OtpArgs {
 Command! {OtpCommand, [
   /// Clears a one-time password slot
   Clear(OtpClearArgs) => |ctx, args: OtpClearArgs| {
-    commands::otp_clear(ctx, args.slot, args.algorithm)
+    crate::commands::otp_clear(ctx, args.slot, args.algorithm)
   },
   /// Generates a one-time password
   Get(OtpGetArgs) => |ctx, args: OtpGetArgs| {
-    commands::otp_get(ctx, args.slot, args.algorithm, args.time)
+    crate::commands::otp_get(ctx, args.slot, args.algorithm, args.time)
   },
   /// Configures a one-time password slot
-  Set(OtpSetArgs) => args::otp_set,
+  Set(OtpSetArgs) => crate::args::otp_set,
   /// Prints the status of the one-time password slots
-  Status(OtpStatusArgs) => |ctx, args: OtpStatusArgs| commands::otp_status(ctx, args.all),
+  Status(OtpStatusArgs) => |ctx, args: OtpStatusArgs| crate::commands::otp_status(ctx, args.all),
 ]}
 
 #[derive(Debug, PartialEq, structopt::StructOpt)]
@@ -322,11 +319,11 @@ pub struct PinArgs {
 
 Command! {PinCommand, [
   /// Clears the cached PINs
-  Clear => commands::pin_clear,
+  Clear => crate::commands::pin_clear,
   /// Changes a PIN
-  Set(PinSetArgs) => |ctx, args: PinSetArgs| commands::pin_set(ctx, args.pintype),
+  Set(PinSetArgs) => |ctx, args: PinSetArgs| crate::commands::pin_set(ctx, args.pintype),
   /// Unblocks and resets the user PIN
-  Unblock => commands::pin_unblock,
+  Unblock => crate::commands::pin_unblock,
 ]}
 
 /// PIN type requested from pinentry.
@@ -354,17 +351,17 @@ pub struct PwsArgs {
 
 Command! {PwsCommand, [
   /// Clears a password safe slot
-  Clear(PwsClearArgs) => |ctx, args: PwsClearArgs| commands::pws_clear(ctx, args.slot),
+  Clear(PwsClearArgs) => |ctx, args: PwsClearArgs| crate::commands::pws_clear(ctx, args.slot),
   /// Reads a password safe slot
   Get(PwsGetArgs) => |ctx, args: PwsGetArgs| {
-    commands::pws_get(ctx, args.slot, args.name, args.login, args.password, args.quiet)
+    crate::commands::pws_get(ctx, args.slot, args.name, args.login, args.password, args.quiet)
   },
   /// Writes a password safe slot
   Set(PwsSetArgs) => |ctx, args: PwsSetArgs| {
-    commands::pws_set(ctx, args.slot, &args.name, &args.login, &args.password)
+    crate::commands::pws_set(ctx, args.slot, &args.name, &args.login, &args.password)
   },
   /// Prints the status of the password safe slots
-  Status(PwsStatusArgs) => |ctx, args: PwsStatusArgs| commands::pws_status(ctx, args.all),
+  Status(PwsStatusArgs) => |ctx, args: PwsStatusArgs| crate::commands::pws_status(ctx, args.all),
 ]}
 
 #[derive(Debug, PartialEq, structopt::StructOpt)]
@@ -419,7 +416,7 @@ pub struct UnencryptedArgs {
 Command! {UnencryptedCommand, [
   /// Changes the configuration of the unencrypted volume on a Nitrokey Storage
   Set(UnencryptedSetArgs) => |ctx, args: UnencryptedSetArgs| {
-    commands::unencrypted_set(ctx, args.mode)
+    crate::commands::unencrypted_set(ctx, args.mode)
   },
 ]}
 

--- a/src/arg_defs.rs
+++ b/src/arg_defs.rs
@@ -19,7 +19,6 @@
 
 use crate::args;
 use crate::commands;
-use crate::error::Error;
 
 /// Provides access to a Nitrokey device
 #[derive(structopt::StructOpt)]
@@ -136,13 +135,13 @@ pub enum ConfigOption<T> {
 }
 
 impl<T> ConfigOption<T> {
-  pub fn try_from(disable: bool, value: Option<T>, name: &'static str) -> Result<Self, Error> {
+  pub fn try_from(disable: bool, value: Option<T>, name: &'static str) -> Result<Self, String> {
     if disable {
       if value.is_some() {
-        Err(Error::Error(format!(
+        Err(format!(
           "--{name} and --no-{name} are mutually exclusive",
           name = name
-        )))
+        ))
       } else {
         Ok(ConfigOption::Disable)
       }

--- a/src/arg_defs.rs
+++ b/src/arg_defs.rs
@@ -20,7 +20,6 @@
 use crate::args;
 use crate::commands;
 use crate::error::Error;
-use crate::pinentry;
 
 /// Provides access to a Nitrokey device
 #[derive(structopt::StructOpt)]
@@ -331,11 +330,21 @@ Command! {PinCommand, [
   Unblock => commands::pin_unblock,
 ]}
 
+/// PIN type requested from pinentry.
+///
+/// The available PIN types correspond to the PIN types used by the Nitrokey devices:  user and
+/// admin.
+#[allow(unused_doc_comments)]
+Enum! {PinType, [
+  Admin => "admin",
+  User => "user",
+]}
+
 #[derive(Debug, PartialEq, structopt::StructOpt)]
 pub struct PinSetArgs {
   /// The PIN type to change
-  #[structopt(name = "type", possible_values = &pinentry::PinType::all_str())]
-  pub pintype: pinentry::PinType,
+  #[structopt(name = "type", possible_values = &PinType::all_str())]
+  pub pintype: PinType,
 }
 
 #[derive(Debug, PartialEq, structopt::StructOpt)]

--- a/src/arg_defs.rs
+++ b/src/arg_defs.rs
@@ -1,0 +1,428 @@
+// arg_defs.rs
+
+// *************************************************************************
+// * Copyright (C) 2020 Daniel Mueller (deso@posteo.net)                   *
+// *                                                                       *
+// * This program is free software: you can redistribute it and/or modify  *
+// * it under the terms of the GNU General Public License as published by  *
+// * the Free Software Foundation, either version 3 of the License, or     *
+// * (at your option) any later version.                                   *
+// *                                                                       *
+// * This program is distributed in the hope that it will be useful,       *
+// * but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+// * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+// * GNU General Public License for more details.                          *
+// *                                                                       *
+// * You should have received a copy of the GNU General Public License     *
+// * along with this program.  If not, see <http://www.gnu.org/licenses/>. *
+// *************************************************************************
+
+use crate::args;
+use crate::commands;
+use crate::error::Error;
+use crate::pinentry;
+
+/// Provides access to a Nitrokey device
+#[derive(structopt::StructOpt)]
+#[structopt(name = "nitrocli")]
+pub struct Args {
+  /// Increases the log level (can be supplied multiple times)
+  #[structopt(short, long, global = true, parse(from_occurrences))]
+  pub verbose: u8,
+  /// Selects the device model to connect to
+  #[structopt(short, long, global = true, possible_values = &DeviceModel::all_str())]
+  pub model: Option<DeviceModel>,
+  #[structopt(subcommand)]
+  pub cmd: Command,
+}
+
+/// The available Nitrokey models.
+#[allow(unused_doc_comments)]
+Enum! {DeviceModel, [
+  Pro => "pro",
+  Storage => "storage",
+]}
+
+impl DeviceModel {
+  pub fn as_user_facing_str(&self) -> &str {
+    match self {
+      DeviceModel::Pro => "Pro",
+      DeviceModel::Storage => "Storage",
+    }
+  }
+}
+
+impl From<DeviceModel> for nitrokey::Model {
+  fn from(model: DeviceModel) -> nitrokey::Model {
+    match model {
+      DeviceModel::Pro => nitrokey::Model::Pro,
+      DeviceModel::Storage => nitrokey::Model::Storage,
+    }
+  }
+}
+
+/// A top-level command for nitrocli.
+#[allow(unused_doc_comments)]
+Command! {Command, [
+  /// Reads or writes the device configuration
+  Config(ConfigArgs) => |ctx, args: ConfigArgs| args.subcmd.execute(ctx),
+  /// Interacts with the device's encrypted volume
+  Encrypted(EncryptedArgs) => |ctx, args: EncryptedArgs| args.subcmd.execute(ctx),
+  /// Interacts with the device's hidden volume
+  Hidden(HiddenArgs) => |ctx, args: HiddenArgs| args.subcmd.execute(ctx),
+  /// Lists the attached Nitrokey devices
+  List(ListArgs) => |ctx, args: ListArgs| commands::list(ctx, args.no_connect),
+  /// Locks the connected Nitrokey device
+  Lock => commands::lock,
+  /// Accesses one-time passwords
+  Otp(OtpArgs) => |ctx, args: OtpArgs| args.subcmd.execute(ctx),
+  /// Manages the Nitrokey PINs
+  Pin(PinArgs) => |ctx, args: PinArgs| args.subcmd.execute(ctx),
+  /// Accesses the password safe
+  Pws(PwsArgs) => |ctx, args: PwsArgs| args.subcmd.execute(ctx),
+  /// Performs a factory reset
+  Reset => commands::reset,
+  /// Prints the status of the connected Nitrokey device
+  Status => commands::status,
+  /// Interacts with the device's unencrypted volume
+  Unencrypted(UnencryptedArgs) => |ctx, args: UnencryptedArgs| args.subcmd.execute(ctx),
+]}
+
+#[derive(Debug, PartialEq, structopt::StructOpt)]
+pub struct ConfigArgs {
+  #[structopt(subcommand)]
+  subcmd: ConfigCommand,
+}
+
+Command! {ConfigCommand, [
+  /// Prints the Nitrokey configuration
+  Get => commands::config_get,
+  /// Changes the Nitrokey configuration
+  Set(ConfigSetArgs) => args::config_set,
+]}
+
+#[derive(Debug, PartialEq, structopt::StructOpt)]
+pub struct ConfigSetArgs {
+  /// Sets the numlock option to the given HOTP slot
+  #[structopt(short = "n", long)]
+  pub numlock: Option<u8>,
+  /// Unsets the numlock option
+  #[structopt(short = "N", long, conflicts_with("numlock"))]
+  pub no_numlock: bool,
+  /// Sets the capslock option to the given HOTP slot
+  #[structopt(short = "c", long)]
+  pub capslock: Option<u8>,
+  /// Unsets the capslock option
+  #[structopt(short = "C", long, conflicts_with("capslock"))]
+  pub no_capslock: bool,
+  /// Sets the scrollock option to the given HOTP slot
+  #[structopt(short = "s", long)]
+  pub scrollock: Option<u8>,
+  /// Unsets the scrollock option
+  #[structopt(short = "S", long, conflicts_with("scrollock"))]
+  pub no_scrollock: bool,
+  /// Requires the user PIN to generate one-time passwords
+  #[structopt(short = "o", long)]
+  pub otp_pin: bool,
+  /// Allows one-time password generation without PIN
+  #[structopt(short = "O", long, conflicts_with("otp-pin"))]
+  pub no_otp_pin: bool,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum ConfigOption<T> {
+  Enable(T),
+  Disable,
+  Ignore,
+}
+
+impl<T> ConfigOption<T> {
+  pub fn try_from(disable: bool, value: Option<T>, name: &'static str) -> Result<Self, Error> {
+    if disable {
+      if value.is_some() {
+        Err(Error::Error(format!(
+          "--{name} and --no-{name} are mutually exclusive",
+          name = name
+        )))
+      } else {
+        Ok(ConfigOption::Disable)
+      }
+    } else {
+      match value {
+        Some(value) => Ok(ConfigOption::Enable(value)),
+        None => Ok(ConfigOption::Ignore),
+      }
+    }
+  }
+
+  pub fn or(self, default: Option<T>) -> Option<T> {
+    match self {
+      ConfigOption::Enable(value) => Some(value),
+      ConfigOption::Disable => None,
+      ConfigOption::Ignore => default,
+    }
+  }
+}
+
+#[derive(Debug, PartialEq, structopt::StructOpt)]
+pub struct EncryptedArgs {
+  #[structopt(subcommand)]
+  subcmd: EncryptedCommand,
+}
+
+Command! {EncryptedCommand, [
+  /// Closes the encrypted volume on a Nitrokey Storage
+  Close => commands::encrypted_close,
+  /// Opens the encrypted volume on a Nitrokey Storage
+  Open => commands::encrypted_open,
+]}
+
+#[derive(Debug, PartialEq, structopt::StructOpt)]
+pub struct HiddenArgs {
+  #[structopt(subcommand)]
+  subcmd: HiddenCommand,
+}
+
+Command! {HiddenCommand, [
+  /// Closes the hidden volume on a Nitrokey Storage
+  Close => commands::hidden_close,
+  /// Creates a hidden volume on a Nitrokey Storage
+  Create(HiddenCreateArgs) => |ctx, args: HiddenCreateArgs| {
+    commands::hidden_create(ctx, args.slot, args.start, args.end)
+  },
+  /// Opens the hidden volume on a Nitrokey Storage
+  Open => commands::hidden_open,
+]}
+
+#[derive(Debug, PartialEq, structopt::StructOpt)]
+pub struct HiddenCreateArgs {
+  /// The hidden volume slot to use
+  pub slot: u8,
+  /// The start location of the hidden volume as a percentage of the encrypted volume's size (0-99)
+  pub start: u8,
+  /// The end location of the hidden volume as a percentage of the encrypted volume's size (1-100)
+  pub end: u8,
+}
+
+#[derive(Debug, PartialEq, structopt::StructOpt)]
+pub struct ListArgs {
+  /// Only print the information that is available without connecting to a device
+  #[structopt(short, long)]
+  pub no_connect: bool,
+}
+
+#[derive(Debug, PartialEq, structopt::StructOpt)]
+pub struct OtpArgs {
+  #[structopt(subcommand)]
+  subcmd: OtpCommand,
+}
+
+Command! {OtpCommand, [
+  /// Clears a one-time password slot
+  Clear(OtpClearArgs) => |ctx, args: OtpClearArgs| {
+    commands::otp_clear(ctx, args.slot, args.algorithm)
+  },
+  /// Generates a one-time password
+  Get(OtpGetArgs) => |ctx, args: OtpGetArgs| {
+    commands::otp_get(ctx, args.slot, args.algorithm, args.time)
+  },
+  /// Configures a one-time password slot
+  Set(OtpSetArgs) => args::otp_set,
+  /// Prints the status of the one-time password slots
+  Status(OtpStatusArgs) => |ctx, args: OtpStatusArgs| commands::otp_status(ctx, args.all),
+]}
+
+#[derive(Debug, PartialEq, structopt::StructOpt)]
+pub struct OtpClearArgs {
+  /// The OTP algorithm to use
+  #[structopt(short, long, default_value = OtpAlgorithm::Totp.as_ref(),
+              possible_values = &OtpAlgorithm::all_str())]
+  pub algorithm: OtpAlgorithm,
+  /// The OTP slot to clear
+  pub slot: u8,
+}
+
+#[derive(Debug, PartialEq, structopt::StructOpt)]
+pub struct OtpGetArgs {
+  /// The OTP algorithm to use
+  #[structopt(short, long, default_value = OtpAlgorithm::Totp.as_ref(),
+              possible_values = &OtpAlgorithm::all_str())]
+  pub algorithm: OtpAlgorithm,
+  /// The time to use for TOTP generation (Unix timestamp) [default: system time]
+  #[structopt(short, long)]
+  pub time: Option<u64>,
+  /// The OTP slot to use
+  pub slot: u8,
+}
+
+#[derive(Debug, PartialEq, structopt::StructOpt)]
+pub struct OtpSetArgs {
+  /// The OTP algorithm to use
+  #[structopt(short, long, default_value = OtpAlgorithm::Totp.as_ref(),
+              possible_values = &OtpAlgorithm::all_str())]
+  pub algorithm: OtpAlgorithm,
+  /// The number of digits to use for the one-time password
+  #[structopt(short, long, default_value = OtpMode::SixDigits.as_ref(),
+              possible_values = &OtpMode::all_str())]
+  pub digits: OtpMode,
+  /// The counter value for HOTP
+  #[structopt(short, long, default_value = "0")]
+  pub counter: u64,
+  /// The time window for TOTP
+  #[structopt(short, long, default_value = "30")]
+  pub time_window: u16,
+  /// The format of the secret
+  #[structopt(short, long, default_value = OtpSecretFormat::Hex.as_ref(),
+              possible_values = &OtpSecretFormat::all_str())]
+  pub format: OtpSecretFormat,
+  /// The OTP slot to use
+  pub slot: u8,
+  /// The name of the slot
+  pub name: String,
+  /// The secret to store on the slot as a hexadecimal string (or in the format set with the
+  /// --format option)
+  pub secret: String,
+}
+
+#[derive(Debug, PartialEq, structopt::StructOpt)]
+pub struct OtpStatusArgs {
+  /// Shows slots that are not programmed
+  #[structopt(short, long)]
+  pub all: bool,
+}
+
+Enum! {OtpAlgorithm, [
+  Hotp => "hotp",
+  Totp => "totp",
+]}
+
+Enum! {OtpMode, [
+  SixDigits => "6",
+  EightDigits => "8",
+]}
+
+impl From<OtpMode> for nitrokey::OtpMode {
+  fn from(mode: OtpMode) -> Self {
+    match mode {
+      OtpMode::SixDigits => nitrokey::OtpMode::SixDigits,
+      OtpMode::EightDigits => nitrokey::OtpMode::EightDigits,
+    }
+  }
+}
+
+Enum! {OtpSecretFormat, [
+  Ascii => "ascii",
+  Base32 => "base32",
+  Hex => "hex",
+]}
+
+#[derive(Debug, PartialEq, structopt::StructOpt)]
+pub struct PinArgs {
+  #[structopt(subcommand)]
+  subcmd: PinCommand,
+}
+
+Command! {PinCommand, [
+  /// Clears the cached PINs
+  Clear => commands::pin_clear,
+  /// Changes a PIN
+  Set(PinSetArgs) => |ctx, args: PinSetArgs| commands::pin_set(ctx, args.pintype),
+  /// Unblocks and resets the user PIN
+  Unblock => commands::pin_unblock,
+]}
+
+#[derive(Debug, PartialEq, structopt::StructOpt)]
+pub struct PinSetArgs {
+  /// The PIN type to change
+  #[structopt(name = "type", possible_values = &pinentry::PinType::all_str())]
+  pub pintype: pinentry::PinType,
+}
+
+#[derive(Debug, PartialEq, structopt::StructOpt)]
+pub struct PwsArgs {
+  #[structopt(subcommand)]
+  subcmd: PwsCommand,
+}
+
+Command! {PwsCommand, [
+  /// Clears a password safe slot
+  Clear(PwsClearArgs) => |ctx, args: PwsClearArgs| commands::pws_clear(ctx, args.slot),
+  /// Reads a password safe slot
+  Get(PwsGetArgs) => |ctx, args: PwsGetArgs| {
+    commands::pws_get(ctx, args.slot, args.name, args.login, args.password, args.quiet)
+  },
+  /// Writes a password safe slot
+  Set(PwsSetArgs) => |ctx, args: PwsSetArgs| {
+    commands::pws_set(ctx, args.slot, &args.name, &args.login, &args.password)
+  },
+  /// Prints the status of the password safe slots
+  Status(PwsStatusArgs) => |ctx, args: PwsStatusArgs| commands::pws_status(ctx, args.all),
+]}
+
+#[derive(Debug, PartialEq, structopt::StructOpt)]
+pub struct PwsClearArgs {
+  /// The PWS slot to clear
+  pub slot: u8,
+}
+
+#[derive(Debug, PartialEq, structopt::StructOpt)]
+pub struct PwsGetArgs {
+  /// Shows the name stored on the slot
+  #[structopt(short, long)]
+  pub name: bool,
+  /// Shows the login stored on the slot
+  #[structopt(short, long)]
+  pub login: bool,
+  /// Shows the password stored on the slot
+  #[structopt(short, long)]
+  pub password: bool,
+  /// Prints the stored data without description
+  #[structopt(short, long)]
+  pub quiet: bool,
+  /// The PWS slot to read
+  pub slot: u8,
+}
+
+#[derive(Debug, PartialEq, structopt::StructOpt)]
+pub struct PwsSetArgs {
+  /// The PWS slot to write
+  pub slot: u8,
+  /// The name to store on the slot
+  pub name: String,
+  /// The login to store on the slot
+  pub login: String,
+  /// The password to store on the slot
+  pub password: String,
+}
+
+#[derive(Debug, PartialEq, structopt::StructOpt)]
+pub struct PwsStatusArgs {
+  /// Shows slots that are not programmed
+  #[structopt(short, long)]
+  pub all: bool,
+}
+
+#[derive(Debug, PartialEq, structopt::StructOpt)]
+pub struct UnencryptedArgs {
+  #[structopt(subcommand)]
+  subcmd: UnencryptedCommand,
+}
+
+Command! {UnencryptedCommand, [
+  /// Changes the configuration of the unencrypted volume on a Nitrokey Storage
+  Set(UnencryptedSetArgs) => |ctx, args: UnencryptedSetArgs| {
+    commands::unencrypted_set(ctx, args.mode)
+  },
+]}
+
+#[derive(Debug, PartialEq, structopt::StructOpt)]
+pub struct UnencryptedSetArgs {
+  /// The mode to change to
+  #[structopt(name = "type", possible_values = &UnencryptedVolumeMode::all_str())]
+  pub mode: UnencryptedVolumeMode,
+}
+
+Enum! {UnencryptedVolumeMode, [
+  ReadWrite => "read-write",
+  ReadOnly => "read-only",
+]}

--- a/src/arg_util.rs
+++ b/src/arg_util.rs
@@ -35,7 +35,7 @@ macro_rules! tr {
 macro_rules! Command {
   ( $name:ident, [ $( $(#[$doc:meta])* $var:ident$(($inner:ty))? => $exec:expr, ) *] ) => {
     #[derive(Debug, PartialEq, structopt::StructOpt)]
-    enum $name {
+    pub enum $name {
       $(
         $(#[$doc])*
         $var$(($inner))?,
@@ -44,7 +44,7 @@ macro_rules! Command {
 
     #[allow(unused_qualifications)]
     impl $name {
-      fn execute(
+      pub fn execute(
         self,
         ctx: &mut crate::args::ExecCtx<'_>,
       ) -> crate::Result<()> {

--- a/src/args.rs
+++ b/src/args.rs
@@ -20,11 +20,10 @@
 use std::ffi;
 use std::io;
 use std::result;
-use std::str;
 
+use crate::arg_defs;
 use crate::commands;
 use crate::error::Error;
-use crate::pinentry;
 use crate::RunCtx;
 
 type Result<T> = result::Result<T, Error>;
@@ -51,7 +50,7 @@ where
 /// A command execution context that captures additional data pertaining
 /// the command execution.
 pub struct ExecCtx<'io> {
-  pub model: Option<DeviceModel>,
+  pub model: Option<arg_defs::DeviceModel>,
   pub stdout: &'io mut dyn io::Write,
   pub stderr: &'io mut dyn io::Write,
   pub admin_pin: Option<ffi::OsString>,
@@ -69,152 +68,10 @@ impl<'io> Stdio for ExecCtx<'io> {
   }
 }
 
-/// Provides access to a Nitrokey device
-#[derive(structopt::StructOpt)]
-#[structopt(name = "nitrocli")]
-struct Args {
-  /// Increases the log level (can be supplied multiple times)
-  #[structopt(short, long, global = true, parse(from_occurrences))]
-  verbose: u8,
-  /// Selects the device model to connect to
-  #[structopt(short, long, global = true, possible_values = &DeviceModel::all_str())]
-  model: Option<DeviceModel>,
-  #[structopt(subcommand)]
-  cmd: Command,
-}
-
-/// The available Nitrokey models.
-#[allow(unused_doc_comments)]
-Enum! {DeviceModel, [
-  Pro => "pro",
-  Storage => "storage",
-]}
-
-impl DeviceModel {
-  pub fn as_user_facing_str(&self) -> &str {
-    match self {
-      DeviceModel::Pro => "Pro",
-      DeviceModel::Storage => "Storage",
-    }
-  }
-}
-
-impl From<DeviceModel> for nitrokey::Model {
-  fn from(model: DeviceModel) -> nitrokey::Model {
-    match model {
-      DeviceModel::Pro => nitrokey::Model::Pro,
-      DeviceModel::Storage => nitrokey::Model::Storage,
-    }
-  }
-}
-
-/// A top-level command for nitrocli.
-#[allow(unused_doc_comments)]
-Command! {Command, [
-  /// Reads or writes the device configuration
-  Config(ConfigArgs) => |ctx, args: ConfigArgs| args.subcmd.execute(ctx),
-  /// Interacts with the device's encrypted volume
-  Encrypted(EncryptedArgs) => |ctx, args: EncryptedArgs| args.subcmd.execute(ctx),
-  /// Interacts with the device's hidden volume
-  Hidden(HiddenArgs) => |ctx, args: HiddenArgs| args.subcmd.execute(ctx),
-  /// Lists the attached Nitrokey devices
-  List(ListArgs) => |ctx, args: ListArgs| commands::list(ctx, args.no_connect),
-  /// Locks the connected Nitrokey device
-  Lock => commands::lock,
-  /// Accesses one-time passwords
-  Otp(OtpArgs) => |ctx, args: OtpArgs| args.subcmd.execute(ctx),
-  /// Manages the Nitrokey PINs
-  Pin(PinArgs) => |ctx, args: PinArgs| args.subcmd.execute(ctx),
-  /// Accesses the password safe
-  Pws(PwsArgs) => |ctx, args: PwsArgs| args.subcmd.execute(ctx),
-  /// Performs a factory reset
-  Reset => commands::reset,
-  /// Prints the status of the connected Nitrokey device
-  Status => commands::status,
-  /// Interacts with the device's unencrypted volume
-  Unencrypted(UnencryptedArgs) => |ctx, args: UnencryptedArgs| args.subcmd.execute(ctx),
-]}
-
-#[derive(Debug, PartialEq, structopt::StructOpt)]
-struct ConfigArgs {
-  #[structopt(subcommand)]
-  subcmd: ConfigCommand,
-}
-
-Command! {ConfigCommand, [
-  /// Prints the Nitrokey configuration
-  Get => commands::config_get,
-  /// Changes the Nitrokey configuration
-  Set(ConfigSetArgs) => config_set,
-]}
-
-#[derive(Debug, PartialEq, structopt::StructOpt)]
-struct ConfigSetArgs {
-  /// Sets the numlock option to the given HOTP slot
-  #[structopt(short = "n", long)]
-  numlock: Option<u8>,
-  /// Unsets the numlock option
-  #[structopt(short = "N", long, conflicts_with("numlock"))]
-  no_numlock: bool,
-  /// Sets the capslock option to the given HOTP slot
-  #[structopt(short = "c", long)]
-  capslock: Option<u8>,
-  /// Unsets the capslock option
-  #[structopt(short = "C", long, conflicts_with("capslock"))]
-  no_capslock: bool,
-  /// Sets the scrollock option to the given HOTP slot
-  #[structopt(short = "s", long)]
-  scrollock: Option<u8>,
-  /// Unsets the scrollock option
-  #[structopt(short = "S", long, conflicts_with("scrollock"))]
-  no_scrollock: bool,
-  /// Requires the user PIN to generate one-time passwords
-  #[structopt(short = "o", long)]
-  otp_pin: bool,
-  /// Allows one-time password generation without PIN
-  #[structopt(short = "O", long, conflicts_with("otp-pin"))]
-  no_otp_pin: bool,
-}
-
-#[derive(Clone, Copy, Debug)]
-pub enum ConfigOption<T> {
-  Enable(T),
-  Disable,
-  Ignore,
-}
-
-impl<T> ConfigOption<T> {
-  fn try_from(disable: bool, value: Option<T>, name: &'static str) -> Result<Self> {
-    if disable {
-      if value.is_some() {
-        Err(Error::Error(format!(
-          "--{name} and --no-{name} are mutually exclusive",
-          name = name
-        )))
-      } else {
-        Ok(ConfigOption::Disable)
-      }
-    } else {
-      match value {
-        Some(value) => Ok(ConfigOption::Enable(value)),
-        None => Ok(ConfigOption::Ignore),
-      }
-    }
-  }
-
-  pub fn or(self, default: Option<T>) -> Option<T> {
-    match self {
-      ConfigOption::Enable(value) => Some(value),
-      ConfigOption::Disable => None,
-      ConfigOption::Ignore => default,
-    }
-  }
-}
-
-fn config_set(ctx: &mut ExecCtx<'_>, args: ConfigSetArgs) -> Result<()> {
-  let numlock = ConfigOption::try_from(args.no_numlock, args.numlock, "numlock")?;
-  let capslock = ConfigOption::try_from(args.no_capslock, args.capslock, "capslock")?;
-  let scrollock = ConfigOption::try_from(args.no_scrollock, args.scrollock, "scrollock")?;
+pub fn config_set(ctx: &mut ExecCtx<'_>, args: arg_defs::ConfigSetArgs) -> Result<()> {
+  let numlock = arg_defs::ConfigOption::try_from(args.no_numlock, args.numlock, "numlock")?;
+  let capslock = arg_defs::ConfigOption::try_from(args.no_capslock, args.capslock, "capslock")?;
+  let scrollock = arg_defs::ConfigOption::try_from(args.no_scrollock, args.scrollock, "scrollock")?;
   let otp_pin = if args.otp_pin {
     Some(true)
   } else if args.no_otp_pin {
@@ -225,159 +82,7 @@ fn config_set(ctx: &mut ExecCtx<'_>, args: ConfigSetArgs) -> Result<()> {
   commands::config_set(ctx, numlock, capslock, scrollock, otp_pin)
 }
 
-#[derive(Debug, PartialEq, structopt::StructOpt)]
-struct EncryptedArgs {
-  #[structopt(subcommand)]
-  subcmd: EncryptedCommand,
-}
-
-Command! {EncryptedCommand, [
-  /// Closes the encrypted volume on a Nitrokey Storage
-  Close => commands::encrypted_close,
-  /// Opens the encrypted volume on a Nitrokey Storage
-  Open => commands::encrypted_open,
-]}
-
-#[derive(Debug, PartialEq, structopt::StructOpt)]
-struct HiddenArgs {
-  #[structopt(subcommand)]
-  subcmd: HiddenCommand,
-}
-
-Command! {HiddenCommand, [
-  /// Closes the hidden volume on a Nitrokey Storage
-  Close => commands::hidden_close,
-  /// Creates a hidden volume on a Nitrokey Storage
-  Create(HiddenCreateArgs) => |ctx, args: HiddenCreateArgs| {
-    commands::hidden_create(ctx, args.slot, args.start, args.end)
-  },
-  /// Opens the hidden volume on a Nitrokey Storage
-  Open => commands::hidden_open,
-]}
-
-#[derive(Debug, PartialEq, structopt::StructOpt)]
-struct HiddenCreateArgs {
-  /// The hidden volume slot to use
-  slot: u8,
-  /// The start location of the hidden volume as a percentage of the encrypted volume's size (0-99)
-  start: u8,
-  /// The end location of the hidden volume as a percentage of the encrypted volume's size (1-100)
-  end: u8,
-}
-
-#[derive(Debug, PartialEq, structopt::StructOpt)]
-struct ListArgs {
-  /// Only print the information that is available without connecting to a device
-  #[structopt(short, long)]
-  no_connect: bool,
-}
-
-#[derive(Debug, PartialEq, structopt::StructOpt)]
-struct OtpArgs {
-  #[structopt(subcommand)]
-  subcmd: OtpCommand,
-}
-
-Command! {OtpCommand, [
-  /// Clears a one-time password slot
-  Clear(OtpClearArgs) => |ctx, args: OtpClearArgs| {
-    commands::otp_clear(ctx, args.slot, args.algorithm)
-  },
-  /// Generates a one-time password
-  Get(OtpGetArgs) => |ctx, args: OtpGetArgs| {
-    commands::otp_get(ctx, args.slot, args.algorithm, args.time)
-  },
-  /// Configures a one-time password slot
-  Set(OtpSetArgs) => otp_set,
-  /// Prints the status of the one-time password slots
-  Status(OtpStatusArgs) => |ctx, args: OtpStatusArgs| commands::otp_status(ctx, args.all),
-]}
-
-#[derive(Debug, PartialEq, structopt::StructOpt)]
-struct OtpClearArgs {
-  /// The OTP algorithm to use
-  #[structopt(short, long, default_value = OtpAlgorithm::Totp.as_ref(),
-              possible_values = &OtpAlgorithm::all_str())]
-  algorithm: OtpAlgorithm,
-  /// The OTP slot to clear
-  slot: u8,
-}
-
-#[derive(Debug, PartialEq, structopt::StructOpt)]
-struct OtpGetArgs {
-  /// The OTP algorithm to use
-  #[structopt(short, long, default_value = OtpAlgorithm::Totp.as_ref(),
-              possible_values = &OtpAlgorithm::all_str())]
-  algorithm: OtpAlgorithm,
-  /// The time to use for TOTP generation (Unix timestamp) [default: system time]
-  #[structopt(short, long)]
-  time: Option<u64>,
-  /// The OTP slot to use
-  slot: u8,
-}
-
-#[derive(Debug, PartialEq, structopt::StructOpt)]
-struct OtpSetArgs {
-  /// The OTP algorithm to use
-  #[structopt(short, long, default_value = OtpAlgorithm::Totp.as_ref(),
-              possible_values = &OtpAlgorithm::all_str())]
-  algorithm: OtpAlgorithm,
-  /// The number of digits to use for the one-time password
-  #[structopt(short, long, default_value = OtpMode::SixDigits.as_ref(),
-              possible_values = &OtpMode::all_str())]
-  digits: OtpMode,
-  /// The counter value for HOTP
-  #[structopt(short, long, default_value = "0")]
-  counter: u64,
-  /// The time window for TOTP
-  #[structopt(short, long, default_value = "30")]
-  time_window: u16,
-  /// The format of the secret
-  #[structopt(short, long, default_value = OtpSecretFormat::Hex.as_ref(),
-              possible_values = &OtpSecretFormat::all_str())]
-  format: OtpSecretFormat,
-  /// The OTP slot to use
-  slot: u8,
-  /// The name of the slot
-  name: String,
-  /// The secret to store on the slot as a hexadecimal string (or in the format set with the
-  /// --format option)
-  secret: String,
-}
-
-#[derive(Debug, PartialEq, structopt::StructOpt)]
-struct OtpStatusArgs {
-  /// Shows slots that are not programmed
-  #[structopt(short, long)]
-  all: bool,
-}
-
-Enum! {OtpAlgorithm, [
-  Hotp => "hotp",
-  Totp => "totp",
-]}
-
-Enum! {OtpMode, [
-  SixDigits => "6",
-  EightDigits => "8",
-]}
-
-impl From<OtpMode> for nitrokey::OtpMode {
-  fn from(mode: OtpMode) -> Self {
-    match mode {
-      OtpMode::SixDigits => nitrokey::OtpMode::SixDigits,
-      OtpMode::EightDigits => nitrokey::OtpMode::EightDigits,
-    }
-  }
-}
-
-Enum! {OtpSecretFormat, [
-  Ascii => "ascii",
-  Base32 => "base32",
-  Hex => "hex",
-]}
-
-fn otp_set(ctx: &mut ExecCtx<'_>, args: OtpSetArgs) -> Result<()> {
+pub fn otp_set(ctx: &mut ExecCtx<'_>, args: arg_defs::OtpSetArgs) -> Result<()> {
   let data = nitrokey::OtpSlotData {
     number: args.slot,
     name: args.name,
@@ -396,122 +101,11 @@ fn otp_set(ctx: &mut ExecCtx<'_>, args: OtpSetArgs) -> Result<()> {
   )
 }
 
-#[derive(Debug, PartialEq, structopt::StructOpt)]
-struct PinArgs {
-  #[structopt(subcommand)]
-  subcmd: PinCommand,
-}
-
-Command! {PinCommand, [
-  /// Clears the cached PINs
-  Clear => commands::pin_clear,
-  /// Changes a PIN
-  Set(PinSetArgs) => |ctx, args: PinSetArgs| commands::pin_set(ctx, args.pintype),
-  /// Unblocks and resets the user PIN
-  Unblock => commands::pin_unblock,
-]}
-
-#[derive(Debug, PartialEq, structopt::StructOpt)]
-struct PinSetArgs {
-  /// The PIN type to change
-  #[structopt(name = "type", possible_values = &pinentry::PinType::all_str())]
-  pintype: pinentry::PinType,
-}
-
-#[derive(Debug, PartialEq, structopt::StructOpt)]
-struct PwsArgs {
-  #[structopt(subcommand)]
-  subcmd: PwsCommand,
-}
-
-Command! {PwsCommand, [
-  /// Clears a password safe slot
-  Clear(PwsClearArgs) => |ctx, args: PwsClearArgs| commands::pws_clear(ctx, args.slot),
-  /// Reads a password safe slot
-  Get(PwsGetArgs) => |ctx, args: PwsGetArgs| {
-    commands::pws_get(ctx, args.slot, args.name, args.login, args.password, args.quiet)
-  },
-  /// Writes a password safe slot
-  Set(PwsSetArgs) => |ctx, args: PwsSetArgs| {
-    commands::pws_set(ctx, args.slot, &args.name, &args.login, &args.password)
-  },
-  /// Prints the status of the password safe slots
-  Status(PwsStatusArgs) => |ctx, args: PwsStatusArgs| commands::pws_status(ctx, args.all),
-]}
-
-#[derive(Debug, PartialEq, structopt::StructOpt)]
-struct PwsClearArgs {
-  /// The PWS slot to clear
-  slot: u8,
-}
-
-#[derive(Debug, PartialEq, structopt::StructOpt)]
-struct PwsGetArgs {
-  /// Shows the name stored on the slot
-  #[structopt(short, long)]
-  name: bool,
-  /// Shows the login stored on the slot
-  #[structopt(short, long)]
-  login: bool,
-  /// Shows the password stored on the slot
-  #[structopt(short, long)]
-  password: bool,
-  /// Prints the stored data without description
-  #[structopt(short, long)]
-  quiet: bool,
-  /// The PWS slot to read
-  slot: u8,
-}
-
-#[derive(Debug, PartialEq, structopt::StructOpt)]
-struct PwsSetArgs {
-  /// The PWS slot to write
-  slot: u8,
-  /// The name to store on the slot
-  name: String,
-  /// The login to store on the slot
-  login: String,
-  /// The password to store on the slot
-  password: String,
-}
-
-#[derive(Debug, PartialEq, structopt::StructOpt)]
-struct PwsStatusArgs {
-  /// Shows slots that are not programmed
-  #[structopt(short, long)]
-  all: bool,
-}
-
-#[derive(Debug, PartialEq, structopt::StructOpt)]
-struct UnencryptedArgs {
-  #[structopt(subcommand)]
-  subcmd: UnencryptedCommand,
-}
-
-Command! {UnencryptedCommand, [
-  /// Changes the configuration of the unencrypted volume on a Nitrokey Storage
-  Set(UnencryptedSetArgs) => |ctx, args: UnencryptedSetArgs| {
-    commands::unencrypted_set(ctx, args.mode)
-  },
-]}
-
-#[derive(Debug, PartialEq, structopt::StructOpt)]
-struct UnencryptedSetArgs {
-  /// The mode to change to
-  #[structopt(name = "type", possible_values = &UnencryptedVolumeMode::all_str())]
-  mode: UnencryptedVolumeMode,
-}
-
-Enum! {UnencryptedVolumeMode, [
-  ReadWrite => "read-write",
-  ReadOnly => "read-only",
-]}
-
 /// Parse the command-line arguments and execute the selected command.
 pub(crate) fn handle_arguments(ctx: &mut RunCtx<'_>, args: Vec<String>) -> Result<()> {
   use structopt::StructOpt;
 
-  match Args::from_iter_safe(args.iter()) {
+  match arg_defs::Args::from_iter_safe(args.iter()) {
     Ok(args) => {
       let mut ctx = ExecCtx {
         model: args.model,

--- a/src/error.rs
+++ b/src/error.rs
@@ -64,6 +64,12 @@ impl From<&str> for Error {
   }
 }
 
+impl From<String> for Error {
+  fn from(s: String) -> Error {
+    Error::Error(s)
+  }
+}
+
 impl From<clap::Error> for Error {
   fn from(e: clap::Error) -> Error {
     Error::ClapError(e)

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,6 +68,7 @@ mod redefine;
 #[macro_use]
 mod arg_util;
 
+mod arg_defs;
 mod args;
 mod commands;
 mod error;

--- a/src/tests/otp.rs
+++ b/src/tests/otp.rs
@@ -19,7 +19,7 @@
 
 use super::*;
 
-use crate::args;
+use crate::arg_defs;
 
 #[test_device]
 fn set_invalid_slot_raw(model: nitrokey::Model) {
@@ -101,8 +101,8 @@ fn set_get_totp(model: nitrokey::Model) -> crate::Result<()> {
 #[test_device]
 fn set_totp_uneven_chars(model: nitrokey::Model) -> crate::Result<()> {
   let secrets = [
-    (args::OtpSecretFormat::Hex, "123"),
-    (args::OtpSecretFormat::Base32, "FBILDWWGA2"),
+    (arg_defs::OtpSecretFormat::Hex, "123"),
+    (arg_defs::OtpSecretFormat::Base32, "FBILDWWGA2"),
   ];
 
   for (format, secret) in &secrets {

--- a/var/shell-complete.rs
+++ b/var/shell-complete.rs
@@ -1,0 +1,59 @@
+// shell-complete.rs
+
+// *************************************************************************
+// * Copyright (C) 2020 Daniel Mueller (deso@posteo.net)                   *
+// *                                                                       *
+// * This program is free software: you can redistribute it and/or modify  *
+// * it under the terms of the GNU General Public License as published by  *
+// * the Free Software Foundation, either version 3 of the License, or     *
+// * (at your option) any later version.                                   *
+// *                                                                       *
+// * This program is distributed in the hope that it will be useful,       *
+// * but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+// * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+// * GNU General Public License for more details.                          *
+// *                                                                       *
+// * You should have received a copy of the GNU General Public License     *
+// * along with this program.  If not, see <http://www.gnu.org/licenses/>. *
+// *************************************************************************
+
+use std::io;
+
+use structopt::clap;
+use structopt::StructOpt as _;
+
+#[allow(unused)]
+mod nitrocli {
+  include!("../src/arg_util.rs");
+
+  // We only need a stripped down version of the `Command` macro.
+  macro_rules! Command {
+    ( $name:ident, [ $( $(#[$doc:meta])* $var:ident$(($inner:ty))? => $exec:expr, ) *] ) => {
+      #[derive(Debug, PartialEq, structopt::StructOpt)]
+      pub enum $name {
+        $(
+          $(#[$doc])*
+          $var$(($inner))?,
+        )*
+      }
+    };
+  }
+
+  include!("../src/arg_defs.rs");
+}
+
+/// Generate a bash completion script for nitrocli.
+///
+/// The script will be emitted to standard output.
+#[derive(Debug, structopt::StructOpt)]
+pub struct Args {
+  /// The command for which to generate the bash completion script.
+  #[structopt(default_value = "nitrocli")]
+  pub command: String,
+}
+
+fn main() {
+  let args = Args::from_args();
+  let mut app = nitrocli::Args::clap();
+  app.gen_completions_to(&args.command, clap::Shell::Bash, &mut io::stdout());
+}

--- a/var/shell-complete.rs
+++ b/var/shell-complete.rs
@@ -52,8 +52,113 @@ pub struct Args {
   pub command: String,
 }
 
+fn generate_bash<W>(command: &str, output: &mut W)
+where
+  W: io::Write,
+{
+  let mut app = nitrocli::Args::clap();
+  app.gen_completions_to(command, clap::Shell::Bash, output);
+}
+
 fn main() {
   let args = Args::from_args();
-  let mut app = nitrocli::Args::clap();
-  app.gen_completions_to(&args.command, clap::Shell::Bash, &mut io::stdout());
+  generate_bash(&args.command, &mut io::stdout())
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  use std::io;
+  use std::ops::Add as _;
+  use std::process;
+
+  /// Separate the given words by newlines.
+  fn lines<'w, W>(mut words: W) -> String
+  where
+    W: Iterator<Item = &'w str>,
+  {
+    let first = words.next().unwrap_or("");
+    words
+      .fold(first.to_string(), |words, word| {
+        format!("{}\n{}", words, word)
+      })
+      .add("\n")
+  }
+
+  /// Check if `bash` is present on the system.
+  fn has_bash() -> bool {
+    match process::Command::new("bash").arg("-c").arg("exit").spawn() {
+      // We deliberately only indicate that bash does not exist if we
+      // get a file-not-found error. We don't expect any other error but
+      // should there be one things will blow up later.
+      Err(ref err) if err.kind() == io::ErrorKind::NotFound => false,
+      _ => true,
+    }
+  }
+
+  /// Perform a bash completion of the given arguments to nitrocli.
+  fn complete_bash<'w, W>(words: W) -> Vec<u8>
+  where
+    W: ExactSizeIterator<Item = &'w str>,
+  {
+    let mut buffer = Vec::new();
+    generate_bash("nitrocli", &mut buffer);
+
+    let script = String::from_utf8(buffer).unwrap();
+    let command = format!(
+      "
+set -e;
+eval '{script}';
+export COMP_WORDS=({words});
+export COMP_CWORD={index};
+_nitrocli;
+echo -n ${{COMPREPLY}}
+      ",
+      index = words.len(),
+      words = lines(Some("nitrocli").into_iter().chain(words)),
+      script = script
+    );
+
+    let output = process::Command::new("bash")
+      .arg("-c")
+      .arg(command)
+      .output()
+      .unwrap();
+
+    output.stdout
+  }
+
+  #[test]
+  fn array_lines() {
+    assert_eq!(&lines(vec![].into_iter()), "\n");
+    assert_eq!(&lines(vec!["first"].into_iter()), "first\n");
+    assert_eq!(
+      &lines(vec!["first", "second"].into_iter()),
+      "first\nsecond\n"
+    );
+    assert_eq!(
+      &lines(vec!["first", "second", "third"].into_iter()),
+      "first\nsecond\nthird\n"
+    );
+  }
+
+  #[test]
+  fn complete_all_the_things() {
+    if !has_bash() {
+      return;
+    }
+
+    assert_eq!(complete_bash(vec!["stat"].into_iter()), b"status");
+    assert_eq!(
+      complete_bash(vec!["status", "--ver"].into_iter()),
+      b"--version"
+    );
+    assert_eq!(complete_bash(vec!["--version"].into_iter()), b"--version");
+    assert_eq!(complete_bash(vec!["--model", "s"].into_iter()), b"storage");
+    assert_eq!(
+      complete_bash(vec!["otp", "get", "--model", "p"].into_iter()),
+      b"pro"
+    );
+  }
 }


### PR DESCRIPTION
This pull request adds support for generating a bash completion script. If
sourced, the shell will provide tab completions for the program's
arguments.
There are two possible approaches provided by clap for going about
generating shell completion functionality: either at build time by
separately generating the clap parsers out-of-band or at run time, as an
option to the main program itself. We are generally not too much in
favor of a run time approach, as it means less inspectability at
installation time and more overhead in the form of code crammed into the
main binary.
Hence, with this change we take the "build time" approach. Clap
recommends hooking the generation up in build.rs, but this seems like an
inflexible choice. For one, that is because it would mean
unconditionally generating this file or some user-unfriendly environment
variable based approach to making the process conditional. But also
because specifying the command for which to generate the script should
likely be configurable. That is a limitation of the completion script
that clap generates (see https://github.com/clap-rs/clap/issues/1764).
Instead, we provide a utility program that emits the completion script
to standard output, accepting regular command line options itself. In
so doing we allow for installation time generation of the completion
script or installation of the utility itself, the output of which could
be sourced on demand -- depending on the user's preference.

---

@robinkrahl If you have the time, can you please take a look? I think we could now think about consolidating `args.rs` and `commands.rs`. Not sure.