### PR TITLE
Declare semver compatibility and public API

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,13 @@ Known Problems
   running shortly afterwards ([upstream issue][libnitrokey#137]).
 
 
+Public API and Stability
+------------------------
+
+**nitrocli** follows the [Semantic Versioning specification 2.0.0][semver].
+Its public API is defined by the [nitrocli(1) `man` page](doc/nitrocli.1.pdf).
+
+
 Contributing
 ------------
 
@@ -179,3 +186,4 @@ the full text of the license.
 [gplv3-tldr]: https://tldrlegal.com/license/gnu-general-public-license-v3-(gpl-3)
 [libnitrokey#32]: https://github.com/Nitrokey/libnitrokey/issues/32
 [libnitrokey#137]: https://github.com/Nitrokey/libnitrokey/issues/137
+[semver]: https://semver.org


### PR DESCRIPTION
This patch adds a new section to the readme that declares that we follow
the Semantic Versioning specification and that the public API of or
crate is defined by the man page.

----

In #112, we talked about the issue of stability and defining nitrocli’s public API.  This patch attempts to solve this issue by declaring the nitrocli man page as nitrocli’s public API.  I think this is a quite elegant solution as it allows us to change implementation details that are not mentioned in the man page (e. g. output formatting) while providing a stable interface to for using nitrocli in scripts and extensions.