### PR TITLE
Introduce builder infrastructure for assembling Nitrocli instance

### DIFF
--- a/src/tests/config.rs
+++ b/src/tests/config.rs
@@ -34,17 +34,24 @@ $"#,
   )
   .unwrap();
 
-  let out = Nitrocli::with_model(model).handle(&["config", "get"])?;
+  let out = Nitrocli::make()
+    .model(model)
+    .build()
+    .handle(&["config", "get"])?;
+
   assert!(re.is_match(&out), out);
   Ok(())
 }
 
 #[test_device]
 fn set_wrong_usage(model: nitrokey::Model) {
-  let err = Nitrocli::with_model(model)
+  let err = Nitrocli::make()
+    .model(model)
+    .build()
     .handle(&["config", "set", "--numlock", "2", "-N"])
     .unwrap_err()
     .to_string();
+
   assert!(
     err.contains("The argument '--numlock <numlock>' cannot be used with '--no-numlock'"),
     err,
@@ -53,7 +60,7 @@ fn set_wrong_usage(model: nitrokey::Model) {
 
 #[test_device]
 fn set_get(model: nitrokey::Model) -> anyhow::Result<()> {
-  let mut ncli = Nitrocli::with_model(model);
+  let mut ncli = Nitrocli::make().model(model).build();
   let _ = ncli.handle(&["config", "set", "-s", "1", "-c", "0", "-N"])?;
 
   let re = regex::Regex::new(

--- a/src/tests/encrypted.rs
+++ b/src/tests/encrypted.rs
@@ -30,7 +30,7 @@ $"#,
     regex::Regex::new(&re).unwrap()
   }
 
-  let mut ncli = Nitrocli::with_model(model);
+  let mut ncli = Nitrocli::make().model(model).build();
   let out = ncli.handle(&["status"])?;
   assert!(make_re(None).is_match(&out), out);
 
@@ -47,10 +47,13 @@ $"#,
 
 #[test_device(pro)]
 fn encrypted_open_on_pro(model: nitrokey::Model) {
-  let err = Nitrocli::with_model(model)
+  let err = Nitrocli::make()
+    .model(model)
+    .build()
     .handle(&["encrypted", "open"])
     .unwrap_err()
     .to_string();
+
   assert_eq!(
     err,
     "This command is only available on the Nitrokey Storage",
@@ -59,7 +62,7 @@ fn encrypted_open_on_pro(model: nitrokey::Model) {
 
 #[test_device(storage)]
 fn encrypted_open_close(model: nitrokey::Model) -> anyhow::Result<()> {
-  let mut ncli = Nitrocli::with_model(model);
+  let mut ncli = Nitrocli::make().model(model).build();
   let out = ncli.handle(&["encrypted", "open"])?;
   assert!(out.is_empty());
 

--- a/src/tests/hidden.rs
+++ b/src/tests/hidden.rs
@@ -7,7 +7,7 @@ use super::*;
 
 #[test_device(storage)]
 fn hidden_create_open_close(model: nitrokey::Model) -> anyhow::Result<()> {
-  let mut ncli = Nitrocli::with_model(model);
+  let mut ncli = Nitrocli::make().model(model).password("1234567").build();
   let out = ncli.handle(&["hidden", "create", "0", "50", "100"])?;
   assert!(out.is_empty());
 

--- a/src/tests/list.rs
+++ b/src/tests/list.rs
@@ -22,7 +22,7 @@ fn connected(model: nitrokey::Model) -> anyhow::Result<()> {
   )
   .unwrap();
 
-  let out = Nitrocli::with_model(model).handle(&["list"])?;
+  let out = Nitrocli::make().model(model).build().handle(&["list"])?;
   assert!(re.is_match(&out), out);
   Ok(())
 }

--- a/src/tests/lock.rs
+++ b/src/tests/lock.rs
@@ -8,7 +8,7 @@ use super::*;
 #[test_device(pro)]
 fn lock_pro(model: nitrokey::Model) -> anyhow::Result<()> {
   // We can't really test much more here than just success of the command.
-  let out = Nitrocli::with_model(model).handle(&["lock"])?;
+  let out = Nitrocli::make().model(model).build().handle(&["lock"])?;
   assert!(out.is_empty());
 
   Ok(())
@@ -16,7 +16,7 @@ fn lock_pro(model: nitrokey::Model) -> anyhow::Result<()> {
 
 #[test_device(storage)]
 fn lock_storage(model: nitrokey::Model) -> anyhow::Result<()> {
-  let mut ncli = Nitrocli::with_model(model);
+  let mut ncli = Nitrocli::make().model(model).build();
   let _ = ncli.handle(&["encrypted", "open"])?;
 
   let out = ncli.handle(&["lock"])?;

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -20,6 +20,30 @@ mod run;
 mod status;
 mod unencrypted;
 
+struct Builder(Nitrocli);
+
+impl Builder {
+  /// Set the model to use.
+  fn model(mut self, model: nitrokey::Model) -> Self {
+    self.0.model = Some(model);
+    self
+  }
+
+  /// Set the password to use for certain operations.
+  fn password<P>(mut self, password: P) -> Self
+  where
+    P: Into<ffi::OsString>,
+  {
+    self.0.password = Some(password.into());
+    self
+  }
+
+  /// Build the final `Nitrocli` object.
+  fn build(self) -> Nitrocli {
+    self.0
+  }
+}
+
 struct Nitrocli {
   model: Option<nitrokey::Model>,
   admin_pin: Option<ffi::OsString>,
@@ -41,18 +65,8 @@ impl Nitrocli {
     }
   }
 
-  pub fn with_model<M>(model: M) -> Self
-  where
-    M: Into<nitrokey::Model>,
-  {
-    Self {
-      model: Some(model.into()),
-      admin_pin: Some(nitrokey::DEFAULT_ADMIN_PIN.into()),
-      user_pin: Some(nitrokey::DEFAULT_USER_PIN.into()),
-      new_admin_pin: None,
-      new_user_pin: None,
-      password: Some("1234567".into()),
-    }
+  pub fn make() -> Builder {
+    Builder(Self::new())
   }
 
   pub fn admin_pin(&mut self, pin: impl Into<ffi::OsString>) {

--- a/src/tests/otp.rs
+++ b/src/tests/otp.rs
@@ -9,8 +9,10 @@ use crate::args;
 
 #[test_device]
 fn set_invalid_slot_raw(model: nitrokey::Model) {
-  let (rc, out, err) =
-    Nitrocli::with_model(model).run(&["otp", "set", "100", "name", "1234", "-f", "hex"]);
+  let (rc, out, err) = Nitrocli::make()
+    .model(model)
+    .build()
+    .run(&["otp", "set", "100", "name", "1234", "-f", "hex"]);
 
   assert_ne!(rc, 0);
   assert_eq!(out, b"");
@@ -19,7 +21,9 @@ fn set_invalid_slot_raw(model: nitrokey::Model) {
 
 #[test_device]
 fn set_invalid_slot(model: nitrokey::Model) {
-  let err = Nitrocli::with_model(model)
+  let err = Nitrocli::make()
+    .model(model)
+    .build()
     .handle(&["otp", "set", "100", "name", "1234", "-f", "hex"])
     .unwrap_err()
     .to_string();
@@ -35,7 +39,7 @@ fn status(model: nitrokey::Model) -> anyhow::Result<()> {
   )
   .unwrap();
 
-  let mut ncli = Nitrocli::with_model(model);
+  let mut ncli = Nitrocli::make().model(model).build();
   // Make sure that we have at least something to display by ensuring
   // that there is one slot programmed.
   let _ = ncli.handle(&["otp", "set", "0", "the-name", "123456", "-f", "hex"])?;
@@ -53,7 +57,7 @@ fn set_get_hotp(model: nitrokey::Model) -> anyhow::Result<()> {
   const OTP1: &str = concat!(755224, "\n");
   const OTP2: &str = concat!(287082, "\n");
 
-  let mut ncli = Nitrocli::with_model(model);
+  let mut ncli = Nitrocli::make().model(model).build();
   let _ = ncli.handle(&[
     "otp", "set", "-a", "hotp", "-f", "ascii", "1", "name", &SECRET,
   ])?;
@@ -74,7 +78,7 @@ fn set_get_totp(model: nitrokey::Model) -> anyhow::Result<()> {
   const TIME: &str = stringify!(1111111111);
   const OTP: &str = concat!(14050471, "\n");
 
-  let mut ncli = Nitrocli::with_model(model);
+  let mut ncli = Nitrocli::make().model(model).build();
   let _ = ncli.handle(&["otp", "set", "-d", "8", "-f", "ascii", "2", "name", &SECRET])?;
 
   let out = ncli.handle(&["otp", "get", "-t", TIME, "2"])?;
@@ -90,7 +94,7 @@ fn set_totp_uneven_chars(model: nitrokey::Model) -> anyhow::Result<()> {
   ];
 
   for (format, secret) in &secrets {
-    let mut ncli = Nitrocli::with_model(model);
+    let mut ncli = Nitrocli::make().model(model).build();
     let _ = ncli.handle(&["otp", "set", "-f", format.as_ref(), "3", "foobar", &secret])?;
   }
   Ok(())
@@ -98,7 +102,7 @@ fn set_totp_uneven_chars(model: nitrokey::Model) -> anyhow::Result<()> {
 
 #[test_device]
 fn clear(model: nitrokey::Model) -> anyhow::Result<()> {
-  let mut ncli = Nitrocli::with_model(model);
+  let mut ncli = Nitrocli::make().model(model).build();
   let _ = ncli.handle(&["otp", "set", "3", "hotp-test", "abcdef"])?;
   let _ = ncli.handle(&["otp", "clear", "3"])?;
   let res = ncli.handle(&["otp", "get", "3"]);

--- a/src/tests/pin.rs
+++ b/src/tests/pin.rs
@@ -21,7 +21,10 @@ fn unblock(model: nitrokey::Model) -> anyhow::Result<()> {
     assert!(device.get_user_retry_count()? < 3);
   }
 
-  let _ = Nitrocli::with_model(model).handle(&["pin", "unblock"])?;
+  let _ = Nitrocli::make()
+    .model(model)
+    .build()
+    .handle(&["pin", "unblock"])?;
 
   {
     let mut manager = nitrokey::force_take()?;
@@ -33,7 +36,7 @@ fn unblock(model: nitrokey::Model) -> anyhow::Result<()> {
 
 #[test_device]
 fn set_user(model: nitrokey::Model) -> anyhow::Result<()> {
-  let mut ncli = Nitrocli::with_model(model);
+  let mut ncli = Nitrocli::make().model(model).build();
   // Set a new user PIN.
   ncli.new_user_pin("new-pin");
   let out = ncli.handle(&["pin", "set", "user"])?;

--- a/src/tests/pws.rs
+++ b/src/tests/pws.rs
@@ -7,7 +7,9 @@ use super::*;
 
 #[test_device]
 fn set_invalid_slot(model: nitrokey::Model) {
-  let err = Nitrocli::with_model(model)
+  let err = Nitrocli::make()
+    .model(model)
+    .build()
     .handle(&["pws", "set", "100", "name", "login", "1234"])
     .unwrap_err()
     .to_string();
@@ -23,7 +25,7 @@ fn status(model: nitrokey::Model) -> anyhow::Result<()> {
   )
   .unwrap();
 
-  let mut ncli = Nitrocli::with_model(model);
+  let mut ncli = Nitrocli::make().model(model).build();
   // Make sure that we have at least something to display by ensuring
   // that there are there is one slot programmed.
   let _ = ncli.handle(&["pws", "set", "0", "the-name", "the-login", "123456"])?;
@@ -39,7 +41,7 @@ fn set_get(model: nitrokey::Model) -> anyhow::Result<()> {
   const LOGIN: &str = "d-e-s-o";
   const PASSWORD: &str = "my-secret-password";
 
-  let mut ncli = Nitrocli::with_model(model);
+  let mut ncli = Nitrocli::make().model(model).build();
   let _ = ncli.handle(&["pws", "set", "1", &NAME, &LOGIN, &PASSWORD])?;
 
   let out = ncli.handle(&["pws", "get", "1", "--quiet", "--name"])?;
@@ -71,7 +73,7 @@ fn set_reset_get(model: nitrokey::Model) -> anyhow::Result<()> {
   const LOGIN: &str = "a\\user";
   const PASSWORD: &str = "!@&-)*(&+%^@";
 
-  let mut ncli = Nitrocli::with_model(model);
+  let mut ncli = Nitrocli::make().model(model).build();
   let _ = ncli.handle(&["pws", "set", "2", &NAME, &LOGIN, &PASSWORD])?;
 
   let out = ncli.handle(&["reset"])?;
@@ -85,7 +87,7 @@ fn set_reset_get(model: nitrokey::Model) -> anyhow::Result<()> {
 
 #[test_device]
 fn clear(model: nitrokey::Model) -> anyhow::Result<()> {
-  let mut ncli = Nitrocli::with_model(model);
+  let mut ncli = Nitrocli::make().model(model).build();
   let _ = ncli.handle(&["pws", "set", "10", "clear-test", "some-login", "abcdef"])?;
   let _ = ncli.handle(&["pws", "clear", "10"])?;
   let res = ncli.handle(&["pws", "get", "10"]);

--- a/src/tests/reset.rs
+++ b/src/tests/reset.rs
@@ -11,7 +11,7 @@ use super::*;
 #[test_device]
 fn reset(model: nitrokey::Model) -> anyhow::Result<()> {
   let new_admin_pin = "87654321";
-  let mut ncli = Nitrocli::with_model(model);
+  let mut ncli = Nitrocli::make().model(model).build();
 
   // Change the admin PIN.
   ncli.new_admin_pin(new_admin_pin);

--- a/src/tests/status.rs
+++ b/src/tests/status.rs
@@ -39,7 +39,7 @@ $"#,
   )
   .unwrap();
 
-  let out = Nitrocli::with_model(model).handle(&["status"])?;
+  let out = Nitrocli::make().model(model).build().handle(&["status"])?;
   assert!(re.is_match(&out), out);
   Ok(())
 }
@@ -65,7 +65,7 @@ $"#,
   )
   .unwrap();
 
-  let out = Nitrocli::with_model(model).handle(&["status"])?;
+  let out = Nitrocli::make().model(model).build().handle(&["status"])?;
   assert!(re.is_match(&out), out);
   Ok(())
 }

--- a/src/tests/unencrypted.rs
+++ b/src/tests/unencrypted.rs
@@ -7,7 +7,7 @@ use super::*;
 
 #[test_device(storage)]
 fn unencrypted_set_read_write(model: nitrokey::Model) -> anyhow::Result<()> {
-  let mut ncli = Nitrocli::with_model(model);
+  let mut ncli = Nitrocli::make().model(model).build();
   let out = ncli.handle(&["unencrypted", "set", "read-write"])?;
   assert!(out.is_empty());
 


### PR DESCRIPTION
In the future we would like to provide more ways for tests to create a
Nitrocli instance. In order to prevent explosion of with_XXX methods for
each possible combination of arguments, this change introduces a Builder
struct that can be used to create such an instance in an idiomatic way.