### PR TITLE
Fix with_storage_device function

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -142,7 +142,7 @@ where
   if let nitrokey::DeviceWrapper::Storage(storage) = device {
     op(ctx, storage)
   } else {
-    panic!("connect returned a wrong model: {:?}", device)
+    panic!("connect returned a wrong model: {}", device.get_model())
   }
 }
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -134,6 +134,8 @@ where
     if model != args::DeviceModel::Storage {
       anyhow::bail!("This command is only available on the Nitrokey Storage");
     }
+  } else {
+    ctx.config.model = Some(args::DeviceModel::Storage);
   }
 
   let device = connect(&mut manager, &ctx.config)?;


### PR DESCRIPTION
This PR fixes a bug in the connection logic of the with_storage_device function and makes the panic message used in the function more concise.