### PR TITLE
Use new PWS access API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,8 +236,7 @@ dependencies = [
 [[package]]
 name = "nitrokey"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48059f1f469143fd371228e33893e6c76419daa9dcb8c0fac2bc1ef2fdfbb7b1"
+source = "git+https://git.sr.ht/~ireas/nitrokey-rs?branch=pws-slots#0bc857cf3a450988005e3a92749c9d256dbe7729"
 dependencies = [
  "lazy_static",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,8 +235,9 @@ dependencies = [
 
 [[package]]
 name = "nitrokey"
-version = "0.8.0"
-source = "git+https://git.sr.ht/~ireas/nitrokey-rs?branch=pws-slots#0bc857cf3a450988005e3a92749c9d256dbe7729"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddeb2d19d5499ab4740c0131562e8c4b2c13f8954677be4318c1efc944911531"
 dependencies = [
  "lazy_static",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,8 @@ version = "0.2"
 version = "0.1"
 
 [dependencies.nitrokey]
-version = "0.8"
+git = "https://git.sr.ht/~ireas/nitrokey-rs"
+branch = "pws-slots"
 
 [dependencies.progressing]
 version = "3.0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,8 +52,7 @@ version = "0.2"
 version = "0.1"
 
 [dependencies.nitrokey]
-git = "https://git.sr.ht/~ireas/nitrokey-rs"
-branch = "pws-slots"
+version = "0.9.0"
 
 [dependencies.progressing]
 version = "3.0.2"

--- a/src/tests/pws.rs
+++ b/src/tests/pws.rs
@@ -67,6 +67,31 @@ fn set_get(model: nitrokey::Model) -> anyhow::Result<()> {
 }
 
 #[test_device]
+fn set_empty(model: nitrokey::Model) -> anyhow::Result<()> {
+  let mut ncli = Nitrocli::new().model(model);
+  let _ = ncli.handle(&["pws", "set", "1", "", "", ""])?;
+
+  let out = ncli.handle(&["pws", "get", "1", "--quiet", "--name"])?;
+  assert_eq!(out, "\n");
+
+  let out = ncli.handle(&["pws", "get", "1", "--quiet", "--login"])?;
+  assert_eq!(out, "\n");
+
+  let out = ncli.handle(&["pws", "get", "1", "--quiet", "--password"])?;
+  assert_eq!(out, "\n");
+
+  let out = ncli.handle(&["pws", "get", "1", "--quiet"])?;
+  assert_eq!(out, "\n\n\n");
+
+  let out = ncli.handle(&["pws", "get", "1"])?;
+  assert_eq!(
+    out,
+    "name:     \nlogin:    \npassword: \n",
+  );
+  Ok(())
+}
+
+#[test_device]
 fn set_reset_get(model: nitrokey::Model) -> anyhow::Result<()> {
   const NAME: &str = "some/svc";
   const LOGIN: &str = "a\\user";


### PR DESCRIPTION
In previous versions of nitrokey-rs, the getters for the name, login and
password fields of a PWS slot would return an error for empty strings as
libnitrokey uses empty strings to indicate unprogrammed slots.  But as
the user might have deliberately specified an empty value, nitrokey-rs
v0.9.0 introduces a new PWS API that makes it possible to distinguish
unprogrammed slots and empty values.

This patch updates the nitrokey-rs dependency and refactors the pws
status and pws get commands to use the new PWS API.

Fixes #133.

To discuss:
- Do we want to support writing completely empty PWS slots, i. e. no name, login or password?