### PR TITLE
Add .editorconfig file for Rust indentation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+# .editorconfig
+
+# Copyright (C) 2021 The Nitrocli Developers
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+[*.rs]
+indent_size = 2


### PR DESCRIPTION
While most editors use the standard 4-space indentation for Rust code,
this project uses two spaces.  To make it easier to write code according
to the project style, this patch adds an .editorconfig file that
specifies the indentation rules.