### PR TITLE
Add cache extension

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -234,6 +234,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nitrocli-cache"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "directories",
+ "regex",
+ "serde",
+ "structopt",
+ "toml",
+]
+
+[[package]]
 name = "nitrokey"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,11 +39,11 @@ version = "1.0"
 [dependencies.base32]
 version = "0.4.0"
 
-[dependencies.envy]
-version = "0.4.2"
-
 [dependencies.directories]
 version = "3"
+
+[dependencies.envy]
+version = "0.4.2"
 
 [dependencies.libc]
 version = "0.2"
@@ -82,3 +82,6 @@ version = "1"
 
 [dev-dependencies.tempfile]
 version = "3.1"
+
+[workspace]
+members = ["ext/*"]

--- a/ext/cache/Cargo.toml
+++ b/ext/cache/Cargo.toml
@@ -1,0 +1,18 @@
+# Cargo.toml
+
+# Copyright (C) 2020-2021 The Nitrocli Developers
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+[package]
+name = "nitrocli-cache"
+version = "0.1.0"
+authors = ["Robin Krahl <robin.krahl@ireas.org>"]
+edition = "2018"
+
+[dependencies]
+anyhow = "1"
+directories = "3"
+regex = "1"
+serde = { version = "1", features = ["derive"] }
+structopt = { version = "0.3.17", default-features = false }
+toml = "0.5"

--- a/ext/cache/src/ext.rs
+++ b/ext/cache/src/ext.rs
@@ -23,7 +23,7 @@ impl Context {
       .context("Failed to retrieve nitrocli path")?;
 
     let verbosity = env::var_os("NITROCLI_VERBOSITY")
-      .context("NITROCLI_VERBOSITY environment variablenot present")
+      .context("NITROCLI_VERBOSITY environment variable not present")
       .context("Failed to retrieve nitrocli verbosity")?;
     let verbosity = if verbosity.len() == 0 {
       None

--- a/ext/cache/src/ext.rs
+++ b/ext/cache/src/ext.rs
@@ -1,0 +1,96 @@
+// ext.rs
+
+// Copyright (C) 2020-2021 The Nitrocli Developers
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use std::env;
+use std::ffi;
+use std::process;
+
+use anyhow::Context as _;
+
+#[derive(Debug)]
+pub struct Context {
+  pub nitrocli: ffi::OsString,
+  pub verbosity: Option<u8>,
+  pub project_dirs: directories::ProjectDirs,
+}
+
+impl Context {
+  pub fn from_env() -> anyhow::Result<Self> {
+    let nitrocli = env::var_os("NITROCLI_BINARY")
+      .context("NITROCLI_BINARY environment variable not present")
+      .context("Failed to retrieve nitrocli path")?;
+
+    let verbosity = env::var_os("NITROCLI_VERBOSITY")
+      .context("NITROCLI_VERBOSITY environment variablenot present")
+      .context("Failed to retrieve nitrocli verbosity")?;
+    let verbosity = if verbosity.len() == 0 {
+      None
+    } else {
+      let verbosity = verbosity
+        .to_str()
+        .context("Provided verbosity string is not valid UTF-8")?;
+      Some(u8::from_str_radix(verbosity, 10).context("Failed to parse verbosity")?)
+    };
+
+    let project_dirs = directories::ProjectDirs::from("", "", "nitrocli-cache")
+      .context("Could not determine the nitrocli-cache application directories")?;
+
+    Ok(Self {
+      nitrocli,
+      verbosity,
+      project_dirs,
+    })
+  }
+}
+
+#[derive(Debug)]
+pub struct Nitrocli {
+  cmd: process::Command,
+}
+
+impl Nitrocli {
+  pub fn from_context(ctx: &Context) -> Nitrocli {
+    let mut cmd = process::Command::new(&ctx.nitrocli);
+    if let Some(verbosity) = ctx.verbosity {
+      for _ in 0..verbosity {
+        cmd.arg("--verbose");
+      }
+    }
+    Self { cmd }
+  }
+
+  pub fn arg(&mut self, arg: impl AsRef<ffi::OsStr>) -> &mut Nitrocli {
+    self.cmd.arg(arg);
+    self
+  }
+
+  pub fn args<I, S>(&mut self, args: I) -> &mut Nitrocli
+  where
+    I: IntoIterator<Item = S>,
+    S: AsRef<ffi::OsStr>,
+  {
+    self.cmd.args(args);
+    self
+  }
+
+  pub fn text(&mut self) -> anyhow::Result<String> {
+    // TODO: inherit stderr from this process to show nitrocli debug messages
+    let output = self.cmd.output().context("Failed to invoke nitrocli")?;
+    if output.status.success() {
+      String::from_utf8(output.stdout).map_err(From::from)
+    } else {
+      Err(anyhow::anyhow!(
+        "nitrocli call failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+      ))
+    }
+  }
+
+  pub fn spawn(&mut self) -> anyhow::Result<()> {
+    let mut child = self.cmd.spawn().context("Failed to invoke nitrocli")?;
+    child.wait().context("Failed to wait on nitrocli")?;
+    Ok(())
+  }
+}

--- a/ext/cache/src/main.rs
+++ b/ext/cache/src/main.rs
@@ -25,7 +25,7 @@ struct Slot {
   id: usize,
 }
 
-/// Access Nitrokey OTP slots by name
+/// Access Nitrokey OTP and PWS slots by name
 #[derive(Debug, structopt::StructOpt)]
 #[structopt(bin_name = "nitrocli cache")]
 struct Args {

--- a/ext/cache/src/main.rs
+++ b/ext/cache/src/main.rs
@@ -1,0 +1,232 @@
+// main.rs
+
+// Copyright (C) 2020-2021 The Nitrocli Developers
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+mod ext;
+
+use std::collections;
+use std::fs;
+use std::io;
+use std::path;
+
+use anyhow::Context as _;
+
+type OtpCache = collections::BTreeMap<String, Vec<Slot>>;
+
+#[derive(Debug, Default, serde::Deserialize, serde::Serialize)]
+struct PwsCache {
+  slots: Vec<Slot>,
+}
+
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
+struct Slot {
+  name: String,
+  id: usize,
+}
+
+/// Access Nitrokey OTP slots by name
+#[derive(Debug, structopt::StructOpt)]
+#[structopt(bin_name = "nitrocli cache")]
+struct Args {
+  #[structopt(subcommand)]
+  cmd: Command,
+}
+
+#[derive(Debug, structopt::StructOpt)]
+enum Command {
+  /// Access the OTP cache
+  Otp(OtpCommand),
+  /// Access the PWS cache
+  Pws(PwsCommand),
+}
+
+#[derive(Debug, structopt::StructOpt)]
+enum OtpCommand {
+  /// Generates a one-time passwords
+  Get {
+    /// The name of the OTP slot to generate a OTP from
+    name: String,
+  },
+  /// Lists the cached slots and their names
+  List,
+  /// Updates the cached slot data
+  Update,
+}
+
+#[derive(Debug, structopt::StructOpt)]
+enum PwsCommand {
+  /// Queries login from the PWS
+  GetLogin {
+    /// The name of the PWS slot to query
+    name: String,
+  },
+  /// Queries password from the PWS
+  GetPassword {
+    /// The name of the PWS slot to query
+    name: String,
+  },
+  /// Lists the cached slots and their names
+  List,
+  /// Updates the cached slot data
+  Update,
+}
+
+fn main() -> anyhow::Result<()> {
+  use structopt::StructOpt as _;
+
+  let args = Args::from_args();
+  let ctx = ext::Context::from_env()?;
+
+  let serial_number = get_serial_number(&ctx)?;
+  let cache_dir = ctx.project_dirs.cache_dir().join(&serial_number);
+  let cache_file = cache_dir.join(match &args.cmd {
+    Command::Otp(_) => "otp.toml",
+    Command::Pws(_) => "pws.toml",
+  });
+
+  match &args.cmd {
+    Command::Otp(cmd) => match cmd {
+      OtpCommand::Get { name } => {
+        let cache: OtpCache = get_cache(&cache_file)?;
+        for (algorithm, slots) in cache {
+          if let Some(slot) = slots.iter().find(|s| &s.name == name) {
+            generate_otp(&ctx, &algorithm, slot.id)?;
+            return Ok(());
+          }
+        }
+        anyhow::bail!("No OTP slot with the given name!");
+      }
+      OtpCommand::List => {
+        let cache: OtpCache = get_cache(&cache_file)?;
+        println!("alg\tslot\tname");
+        for (algorithm, slots) in cache {
+          for slot in slots {
+            println!("{}\t{}\t{}", algorithm, slot.id, slot.name);
+          }
+        }
+      }
+      OtpCommand::Update => {
+        let data = get_otp_slots(&ctx)?;
+        save_cache(&data, &cache_file)?;
+      }
+    },
+    Command::Pws(cmd) => match cmd {
+      PwsCommand::GetLogin { name } => {
+        let cache: PwsCache = get_cache(&cache_file)?;
+        if let Some(slot) = cache.slots.iter().find(|s| &s.name == name) {
+          get_pws_data(&ctx, slot.id, "--login")?;
+        } else {
+          anyhow::bail!("No PWS slot with the given name!");
+        }
+      }
+      PwsCommand::GetPassword { name } => {
+        let cache: PwsCache = get_cache(&cache_file)?;
+        if let Some(slot) = cache.slots.iter().find(|s| &s.name == name) {
+          get_pws_data(&ctx, slot.id, "--password")?;
+        } else {
+          anyhow::bail!("No PWS slot with the given name!");
+        }
+      }
+      PwsCommand::List => {
+        let cache: PwsCache = get_cache(&cache_file)?;
+        println!("slot\tname");
+        for slot in cache.slots {
+          println!("{}\t{}", slot.id, slot.name);
+        }
+      }
+      PwsCommand::Update => {
+        let data = get_pws_slots(&ctx)?;
+        save_cache(&data, &cache_file)?;
+      }
+    },
+  }
+
+  Ok(())
+}
+
+fn get_cache<T: serde::de::DeserializeOwned>(file: &path::Path) -> anyhow::Result<T> {
+  if !file.is_file() {
+    anyhow::bail!("There is no cached slot data.  Run the update command to initialize the cache.");
+  }
+  load_cache(&file)
+}
+
+fn load_cache<T: serde::de::DeserializeOwned>(path: &path::Path) -> anyhow::Result<T> {
+  let s = fs::read_to_string(path).context("Failed to read cache file")?;
+  toml::from_str(&s).context("Failed to parse cache file")
+}
+
+fn save_cache<T: serde::Serialize>(cache: &T, path: &path::Path) -> anyhow::Result<()> {
+  use io::Write as _;
+
+  if let Some(parent) = path.parent() {
+    fs::create_dir_all(parent).context("Failed to create cache parent directory")?;
+  }
+  let mut f = fs::File::create(path).context("Failed to create cache file")?;
+  f.write_all(&toml::to_vec(cache).context("Failed to serialize cache")?)
+    .context("Failed to write cache file")?;
+  Ok(())
+}
+
+fn get_serial_number(ctx: &ext::Context) -> anyhow::Result<String> {
+  let status = ext::Nitrocli::from_context(ctx)
+    .arg("status")
+    .text()
+    .context("Failed to query device status")?;
+  let r = regex::Regex::new(r#"(?m)^\s*serial number:\s*(\S.*)$"#)
+    .context("Failed to compile serial regex")?;
+  let captures = r
+    .captures(&status)
+    .context("Could not find serial number in status output")?;
+  Ok(captures[1].to_lowercase())
+}
+
+fn get_otp_slots(ctx: &ext::Context) -> anyhow::Result<OtpCache> {
+  let slots = ext::Nitrocli::from_context(ctx)
+    .args(&["otp", "status"])
+    .text()?;
+  let mut cache = OtpCache::new();
+  for line in slots.lines().skip(1) {
+    let parts: Vec<_> = line.splitn(3, "\t").collect();
+    if parts.len() == 3 {
+      let algorithm = parts[0].to_owned();
+      let id: usize = parts[1].parse().context("Failed to parse slot ID")?;
+      let name = parts[2].to_owned();
+      cache.entry(algorithm).or_default().push(Slot { name, id });
+    }
+  }
+  Ok(cache)
+}
+
+fn generate_otp(ctx: &ext::Context, algorithm: &str, slot: usize) -> anyhow::Result<()> {
+  ext::Nitrocli::from_context(ctx)
+    .args(&["otp", "get"])
+    .arg(slot.to_string())
+    .arg("--algorithm")
+    .arg(algorithm)
+    .spawn()
+}
+
+fn get_pws_slots(ctx: &ext::Context) -> anyhow::Result<PwsCache> {
+  let slots = ext::Nitrocli::from_context(ctx)
+    .args(&["pws", "status"])
+    .text()?;
+  let mut cache = PwsCache::default();
+  for line in slots.lines().skip(1) {
+    let parts: Vec<_> = line.splitn(2, "\t").collect();
+    if parts.len() == 2 {
+      let id: usize = parts[0].parse().context("Failed to parse slot ID")?;
+      let name = parts[1].to_owned();
+      cache.slots.push(Slot { name, id });
+    }
+  }
+  Ok(cache)
+}
+
+fn get_pws_data(ctx: &ext::Context, slot: usize, type_arg: &str) -> anyhow::Result<()> {
+  ext::Nitrocli::from_context(ctx)
+    .args(&["pws", "get", type_arg, "--quiet"])
+    .arg(slot.to_string())
+    .spawn()
+}


### PR DESCRIPTION
This patch adds the nitrocli-cache extension that caches OTP and PWS
data.  The per-device cache stores the names and IDs of the slots (and
the algorithm for OTP slots).  It can be used to access the slots by
name instead of slot index.

----

The differences to previous versions ([1][], [2][]) are:
- This patch has support for the PWS.
- This patch does not use nitrokey-rs directly, but invokes nitrocli and
  parses its output.  The reasoning for this is that re-implementing the
  device selection based on the values of the NITROCLI_MODEL,
  NITROCLI_USB_PATH and NITROCLI_SERIAL_NUMBER is unnecessarily complex.
- This patch does not try to parse data like the OTP algorithm.  We
  don’t need this information in nitrocli-cache, so we can treat it as
  an opaque string that is handled only by nitrocli itself.

Fixes #83.

[1]: https://github.com/robinkrahl/nitrocli/commit/446e78b95a2d2b74afb9ab7c39bf135ee5e8ab32
[2]: https://github.com/d-e-s-o/nitrocli/commit/269a7ae943a704ed35545e8758c89af55628d0cb