### PR TITLE
Fix cache ID for pinentry calls

### DIFF
--- a/src/pinentry.rs
+++ b/src/pinentry.rs
@@ -58,7 +58,12 @@ impl PinEntry {
 
 impl SecretEntry for PinEntry {
   fn cache_id(&self) -> Option<CowStr> {
-    let model = self.model.to_string().to_lowercase();
+    let model = match self.model {
+      nitrokey::Model::Librem => "librem",
+      nitrokey::Model::Pro => "pro",
+      nitrokey::Model::Storage => "storage",
+      _ => "unknown",
+    };
     let suffix = format!("{}:{}", model, self.serial);
     let cache_id = match self.pin_type {
       args::PinType::Admin => format!("nitrocli:admin:{}", suffix),
@@ -77,7 +82,7 @@ impl SecretEntry for PinEntry {
 
   fn description(&self, mode: Mode) -> CowStr {
     format!(
-      "{} for\r {} {}",
+      "{} for\r{} {}",
       match self.pin_type {
         args::PinType::Admin => match mode {
           Mode::Choose => "Please enter a new admin PIN",
@@ -135,7 +140,7 @@ impl SecretEntry for PwdEntry {
 
   fn description(&self, mode: Mode) -> CowStr {
     format!(
-      "{} for\r {} {}",
+      "{} for\r{} {}",
       match mode {
         Mode::Choose => "Please enter a new hidden volume password",
         Mode::Confirm => "Please confirm the new hidden volume password",


### PR DESCRIPTION
Since nitrokey-rs v0.8.0 added support for the Librem Key, the Display
implementation for nitrokey::Model may include a space, for example
"Nitrokey Pro" (instead of "Pro").  I missed that we used this string
representation to generate the pinentry cache ID, leading to an
additional space in the GnuPG GET_PASSPHRASE call.  This messed up the
error message, prompt and description arguments that come after the
cache ID.

With this patch, we use a hard-coded string for the cache IDs instead of
nitrokey::Model’s Display implementation.