### PR TITLE
Add libnitrokey version to -V/--version output

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -8,7 +8,7 @@ use std::ffi;
 
 /// Provides access to a Nitrokey device
 #[derive(Debug, structopt::StructOpt)]
-#[structopt(name = "nitrocli")]
+#[structopt(name = "nitrocli", no_version)]
 pub struct Args {
   /// Increases the log level (can be supplied multiple times)
   #[structopt(short, long, global = true, parse(from_occurrences))]

--- a/src/main.rs
+++ b/src/main.rs
@@ -110,8 +110,11 @@ impl error::Error for DirectExitError {}
 
 /// Parse the command-line arguments and execute the selected command.
 fn handle_arguments(ctx: &mut Context<'_>, argv: Vec<String>) -> anyhow::Result<()> {
-  match args::Args::from_iter_safe(argv.iter()) {
-    Ok(args) => {
+  let version = get_version_string();
+  let clap = args::Args::clap().version(version.as_str());
+  match clap.get_matches_from_safe(argv.iter()) {
+    Ok(matches) => {
+      let args = args::Args::from_clap(&matches);
       ctx.config.update(&args);
       args.cmd.execute(ctx)
     }
@@ -154,6 +157,15 @@ fn handle_arguments(ctx: &mut Context<'_>, argv: Vec<String>) -> anyhow::Result<
         Ok(())
       }
     }
+  }
+}
+
+fn get_version_string() -> String {
+  let version = env!("CARGO_PKG_VERSION");
+  if let Ok(library_version) = nitrokey::get_library_version() {
+    format!("{} using libnitrokey {}", version, library_version)
+  } else {
+    format!("{} using an undetectable libnitrokey version", version)
   }
 }
 

--- a/src/tests/run.rs
+++ b/src/tests/run.rs
@@ -100,7 +100,7 @@ fn version_option() {
     assert!(re.is_match(&s), out);
   }
 
-  let re = regex::Regex::new(r"^nitrocli \d+.\d+.\d+(-[^-]+)*\n$").unwrap();
+  let re = regex::Regex::new(r"^nitrocli \d+.\d+.\d+(-[^-]+)* using libnitrokey .*\n$").unwrap();
 
   test(&re, "--version");
   test(&re, "-V");


### PR DESCRIPTION
Currently, it is hard to determine the libnitrokey version used by
nitrocli unless it is linked against a shared library.  This patch adds
the libnitrokey version (nitrokey::get_library_version()) to the
-V/--version output.

Fixes #147.