### PR TITLE
Add overwrite option to pws set command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Unreleased
 - Bumped `nitrokey` dependency to `0.9.0`
 - Added the `--only-aes-key` option to the `reset` command to build a new AES
   key without performing a factory reset
+- Added the `--overwrite` option to `pws set` and changed the default behavior
+  to not overwrite programmed slots
 
 
 0.4.0

--- a/doc/nitrocli.1
+++ b/doc/nitrocli.1
@@ -273,11 +273,15 @@ The fields are printed together with a label.
 Use the \fB\-\-quiet\fR option to suppress the labels and to only output the
 values stored in the PWS slot.
 .TP
-\fBnitrocli pws set \fIslot name login password\fR
+\fBnitrocli pws set \fR[\fB\-o\fR|\fB\-\-overwrite\fR] \
+\fIslot name login password\fR
 Set the content of a PWS slot.
 \fIslot\fR is the number of the slot to write.
 \fIname\fR, \fIlogin\fR, and \fIpassword\fR represent the data to write to the
 slot.
+Per default, this command refuses to overwrite programmed slots.
+Set the \fB\-\-overwrite\fR option or use the \fBpws update\fR command if you
+want to overwrite a slot.
 .TP
 \fBnitrocli pws clear \fIslot\fR
 Delete the data stored in a PWS slot.

--- a/src/args.rs
+++ b/src/args.rs
@@ -396,7 +396,7 @@ Command! {PwsCommand, [
   },
   /// Writes a password safe slot
   Set(PwsSetArgs) => |ctx, args: PwsSetArgs| {
-    crate::commands::pws_set(ctx, args.slot, &args.name, &args.login, &args.password)
+    crate::commands::pws_set(ctx, args.slot, &args.name, &args.login, &args.password, args.overwrite)
   },
   /// Prints the status of the password safe slots
   Status(PwsStatusArgs) => |ctx, args: PwsStatusArgs| crate::commands::pws_status(ctx, args.all),
@@ -428,6 +428,9 @@ pub struct PwsGetArgs {
 
 #[derive(Debug, PartialEq, structopt::StructOpt)]
 pub struct PwsSetArgs {
+  /// Overwrite the slot if it is currently programmed
+  #[structopt(short, long)]
+  pub overwrite: bool,
   /// The PWS slot to write
   pub slot: u8,
   /// The name to store on the slot


### PR DESCRIPTION
This patch adds the --overwrite option to the pws set command and
changes the default behavior to refuse overwriting programmed slots.

----

I originally suggested this change in #139 but I think I’ve changed my mind:  This form of the `pws set` command is pretty useless.  If I want to overwrite a slot I should rather use `pws update`.  If I want to add a new slot I most likely want to use `pws add`.  Only if I want to set a specific slot I need `pws set`.

At the same time, changing the default behavior is a already breaking change.  Why not remove `pws set` completely while at it and add a `--slot` option to `pws add` if I really want to write a specific slot?