### PR TITLE
Remove pws set

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: [1.43.1, stable, beta, nightly]
+        rust: [1.42.0, stable, beta, nightly]
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.43.1
+          toolchain: 1.42.0
           components: clippy
           override: true
       - run: cargo clippy --workspace --all-targets --all-features --verbose -- -A unknown_lints -D warnings
@@ -62,7 +62,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.43.1
+          toolchain: 1.42.0
           components: rustfmt
           override: true
       - run: cargo fmt --all -- --check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ Unreleased
 - Allowed entering of `base32` encoded strings containing spaces
 - Fixed pinentry dialog highlighting some messages incorrectly as errors
 - Switched to using GitHub Actions as the project's CI pipeline
-- Updated minimum supported Rust version to `1.43.0`
 - Bumped `nitrokey` dependency to `0.9.0`
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Unreleased
 - Changed error reporting format to make up only a single line
 - Added the `pws add` subcommand to write to a new slot
 - Added the `pws update` subcommand to update an existing PWS slot
+- Removed the `pws set` subcommand – use `pws add` or `pws update` instead
 - Added the `--only-aes-key` option to the `reset` command to build a new AES
   key without performing a factory reset
 - Added `NITROCLI_RESOLVED_USB_PATH` environment variable to be used by

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![pipeline](https://gitlab.com/d-e-s-o/nitrocli/badges/master/pipeline.svg)](https://gitlab.com/d-e-s-o/nitrocli/commits/master)
 [![crates.io](https://img.shields.io/crates/v/nitrocli.svg)](https://crates.io/crates/nitrocli)
-[![rustc](https://img.shields.io/badge/rustc-1.43+-blue.svg)](https://blog.rust-lang.org/2020/04/23/Rust-1.43.0.html)
+[![rustc](https://img.shields.io/badge/rustc-1.42+-blue.svg)](https://blog.rust-lang.org/2020/03/12/Rust-1.42.html)
 
 nitrocli
 ========

--- a/doc/nitrocli.1
+++ b/doc/nitrocli.1
@@ -1,4 +1,4 @@
-.TH NITROCLI 1 2021-04-18
+.TH NITROCLI 1 2021-04-20
 .SH NAME
 nitrocli \- access Nitrokey devices
 .SH SYNOPSIS
@@ -273,12 +273,6 @@ The fields are printed together with a label.
 Use the \fB\-\-quiet\fR option to suppress the labels and to only output the
 values stored in the PWS slot.
 .TP
-\fBnitrocli pws set \fIslot name login password\fR
-Set the content of a PWS slot.
-\fIslot\fR is the number of the slot to write.
-\fIname\fR, \fIlogin\fR, and \fIpassword\fR represent the data to write to the
-slot.
-.TP
 \fBnitrocli pws add \fR[\fB\-s\fR|\fB\-\-slot \fIslot\fR] \
 \fIname login password\fR
 Add a new PWS slot.
@@ -540,7 +534,8 @@ Change the configuration:
 
 .SS Password safe
 Configure a PWS slot:
-    $ \fBnitrocli pws set 0 example.org john.doe passw0rd\fR
+    $ \fBnitrocli pws add example.org john.doe passw0rd\fR
+    Added PWS slot 0
 
 Get the data from a slot:
     $ \fBnitrocli pws get 0\fR

--- a/src/args.rs
+++ b/src/args.rs
@@ -394,10 +394,6 @@ Command! {PwsCommand, [
   Get(PwsGetArgs) => |ctx, args: PwsGetArgs| {
     crate::commands::pws_get(ctx, args.slot, args.name, args.login, args.password, args.quiet)
   },
-  /// Writes a password safe slot
-  Set(PwsSetArgs) => |ctx, args: PwsSetArgs| {
-    crate::commands::pws_set(ctx, args.slot, &args.name, &args.login, &args.password)
-  },
   /// Adds a new password safe slot
   Add(PwsAddArgs) => |ctx, args: PwsAddArgs| {
     crate::commands::pws_add(ctx, &args.name, &args.login, &args.password, args.slot)
@@ -438,18 +434,6 @@ pub struct PwsGetArgs {
   pub quiet: bool,
   /// The PWS slot to read
   pub slot: u8,
-}
-
-#[derive(Debug, PartialEq, structopt::StructOpt)]
-pub struct PwsSetArgs {
-  /// The PWS slot to write
-  pub slot: u8,
-  /// The name to store on the slot
-  pub name: String,
-  /// The login to store on the slot
-  pub login: String,
-  /// The password to store on the slot
-  pub password: String,
 }
 
 #[derive(Debug, PartialEq, structopt::StructOpt)]

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1032,21 +1032,6 @@ pub fn pws_get(
   })
 }
 
-/// Write a PWS slot.
-pub fn pws_set(
-  ctx: &mut Context<'_>,
-  slot: u8,
-  name: &str,
-  login: &str,
-  password: &str,
-) -> anyhow::Result<()> {
-  with_password_safe(ctx, |_ctx, mut pws| {
-    pws
-      .write_slot(slot, name, login, password)
-      .context("Failed to write PWS slot")
-  })
-}
-
 /// Add a new PWS slot.
 pub fn pws_add(
   ctx: &mut Context<'_>,

--- a/src/tests/pws.rs
+++ b/src/tests/pws.rs
@@ -150,7 +150,15 @@ fn clear(model: nitrokey::Model) -> anyhow::Result<()> {
 
   let mut ncli = Nitrocli::new().model(model);
   let _ = ncli.handle(&["pws", "clear", "10"])?;
-  let _ = ncli.handle(&["pws", "add", "--slot", "10", "clear-test", "some-login", "abcdef"])?;
+  let _ = ncli.handle(&[
+    "pws",
+    "add",
+    "--slot",
+    "10",
+    "clear-test",
+    "some-login",
+    "abcdef",
+  ])?;
   let _ = ncli.handle(&["pws", "clear", "10"])?;
   let res = ncli.handle(&["pws", "get", "10"]);
 

--- a/src/tests/run.rs
+++ b/src/tests/run.rs
@@ -75,7 +75,8 @@ fn help_options() {
   test(&["pws"]);
   test(&["pws", "clear"]);
   test(&["pws", "get"]);
-  test(&["pws", "set"]);
+  test(&["pws", "add"]);
+  test(&["pws", "update"]);
   test(&["pws", "status"]);
   test(&["reset"]);
   test(&["status"]);


### PR DESCRIPTION
This patch removes the pws set subcommand as part of the PWS interface
refactoring, see #139.  Users should use pws add (for writing to new slots) or pws
update (for writing to existing slots) instead.  This makes it less
likely to accidentally overwrite PWS data.