### PR TITLE
Document scdaemon workaround in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,8 +143,10 @@ Known Problems
   accessed by `nitrokey-app` ([upstream issue][libnitrokey#32]). To
   prevent this problem, quit `nitrokey-app` before using `nitrocli`.
 - Applications using the Nitrokey device (such as `nitrocli` or
-  `nitrokey-app`) cannot easily share access with an instance of GnuPG
-  running shortly afterwards ([upstream issue][libnitrokey#137]).
+  `nitrokey-app`) cannot easily share access with an instance of scdaemon/GnuPG
+  running shortly afterwards ([upstream issue][libnitrokey#137]).  As a
+  workaround, users can kill scdaemon after calling `nitrocli` with
+  `gpg-connect-agent 'SCD KILLSCD' /bye`.
 
 
 Public API and Stability


### PR DESCRIPTION
We mentioned the libnitrokey/scdaemon incompatibility leading to a
hanging Nitrokey [0] in the readme, but did not explain how to deal with
this issue.  With this patch, we mention that killing scdaemon after
running nitrocli mitigates the problem.  Fixes #164.

[0] https://github.com/Nitrokey/libnitrokey/issues/137