### PR TITLE
Add Nix flake

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,39 @@ $ cargo build --release
 It is recommended that the resulting executable be installed in a
 directory accessible via the `PATH` environment variable.
 
+#### With Nix flakes
+##### Running nitrocli
+
+Repository comes with a `flake.nix` file, so it can be run directly:
+
+``` sh
+$ nix run d-e-s-o/nitrocli
+```
+##### Installing system-wide
+
+`nitrocli` can be installed by adding the repository flake as an input:
+
+``` nix
+{
+  inputs = {
+    nitrocli.url = "github:d-e-s-o/nitrocli?dir=contrib/nix";
+    ...
+  };
+
+  outputs = {
+    nitrocli,
+    ...
+  }:
+  {
+    # ...
+    # Where modules are defined
+    environment.systemPackages = [ nitrocli.defaultPackage ];
+    };
+    # ...
+}
+```
+
+
 
 #### Shell Completion
 **nitrocli** comes with completion support for options and arguments to

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -1,0 +1,6 @@
+This is the `contrib/` directory of nitorcli project. Files located here:
+
+* Are provided by the community of the project
+* Are not official part of the project
+* Are provided without any warranty
+

--- a/contrib/README.md.license
+++ b/contrib/README.md.license
@@ -1,0 +1,2 @@
+Copyright (C) 2020 The Nitrocli Developers
+SPDX-License-Identifier: CC0-1.0

--- a/contrib/nix/flake.lock
+++ b/contrib/nix/flake.lock
@@ -1,0 +1,77 @@
+{
+  "nodes": {
+    "naersk": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1662220400,
+        "narHash": "sha256-9o2OGQqu4xyLZP9K6kNe1pTHnyPz0Wr3raGYnr9AIgY=",
+        "owner": "nix-community",
+        "repo": "naersk",
+        "rev": "6944160c19cb591eb85bbf9b2f2768a935623ed3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "master",
+        "repo": "naersk",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1663264531,
+        "narHash": "sha256-2ncO5chPXlTxaebDlhx7MhL0gOEIWxzSyfsl0r0hxQk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "454887a35de6317a30be284e8adc2d2f6d8a07c4",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1663264531,
+        "narHash": "sha256-2ncO5chPXlTxaebDlhx7MhL0gOEIWxzSyfsl0r0hxQk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "454887a35de6317a30be284e8adc2d2f6d8a07c4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "naersk": "naersk",
+        "nixpkgs": "nixpkgs_2",
+        "utils": "utils"
+      }
+    },
+    "utils": {
+      "locked": {
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/contrib/nix/flake.lock.license
+++ b/contrib/nix/flake.lock.license
@@ -1,0 +1,2 @@
+Copyright (C) 2020 The Nitrocli Developers
+SPDX-License-Identifier: CC0-1.0

--- a/contrib/nix/flake.nix
+++ b/contrib/nix/flake.nix
@@ -1,0 +1,44 @@
+# Copyright (C) 2020 The Nitrocli Developers
+# SPDX-License-Identifier: CC0-1.0
+{
+  inputs = {
+    naersk.url = "github:nix-community/naersk/master";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, utils, naersk }:
+    utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+        naersk-lib = pkgs.callPackage naersk { };
+      in
+      rec
+      {
+        packages.default = naersk-lib.buildPackage {
+          root = ./../../.;
+          nativeBuildInputs = with pkgs; [ hidapi ];
+          postInstall = ''
+            # copy the manpages
+            install -D --mode 0644 ${./../../.}/doc/nitrocli.1 $out/share/man/man1
+            # make completions
+            mkdir --parents $out/share/bash-completion/completions/
+            cargo run --bin=shell-complete bash > $out/share/bash-completion/completions/nitrocli
+            mkdir --parents $out/share/zsh/site-functions/
+            cargo run --bin=shell-complete zsh > $out/share/zsh/site-functions/_nitrocli
+            mkdir --parents $out/share/fish/vendor_completions.d/
+            cargo run --bin=shell-complete fish > $out/share/fish/vendor_completions.d/nitrocli.fish
+          '';
+        };
+
+        apps.default = utils.lib.mkApp {
+          drv = packages.default;
+          name = "nitrocli";
+        };
+
+        devShell = with pkgs; mkShell {
+          buildInputs = [ cargo rustc rustfmt pre-commit rustPackages.clippy hidapi ];
+          RUST_SRC_PATH = rustPlatform.rustLibSrc;
+        };
+      });
+}


### PR DESCRIPTION
This commit embeds a Nix flake into the repository allowing a Nix user to run nitrocli by issuing:

    nix run d-e-s-o/nitrocli

This also adds a reproducible way to install nitrocli on a system controlled by Nix flakes.