### PR TITLE
Add NixOS package to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Packages are available for:
 - Arch Linux: [`nitrocli`][nitrocli-arch]
 - Debian: [`nitrocli`][nitrocli-debian] (since Debian Buster)
 - Gentoo Linux: [`app-crypt/nitrocli`][nitrocli-gentoo] ebuild
+- NixOS: [`nitrocli`][nitrocli-nixos]
 - Ubuntu: [`nitrocli`][nitrocli-ubuntu] (since Ubuntu 19.04)
 
 #### From Crates.io
@@ -226,6 +227,7 @@ the full text of the license.
 [nitrocli-cratesio]: https://crates.io/crates/nitrocli
 [nitrocli-debian]: https://packages.debian.org/stable/nitrocli
 [nitrocli-gentoo]: https://packages.gentoo.org/packages/app-crypt/nitrocli
+[nitrocli-nixos]: https://search.nixos.org/packages?channel=unstable&show=nitrocli
 [nitrocli-ubuntu]: https://packages.ubuntu.com/search?keywords=nitrocli
 [gplv3-tldr]: https://tldrlegal.com/license/gnu-general-public-license-v3-(gpl-3)
 [libnitrokey#32]: https://github.com/Nitrokey/libnitrokey/issues/32


### PR DESCRIPTION
This patch adds a link to the NixOS package for nitrocli to the readme. The package is currently available on the unstable channel and will probably arrive in stable with release 25.05.